### PR TITLE
test: add comprehensive unit tests as regression safety net

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Type-check
         run: pnpm type-check
 
-      - name: Test
-        run: pnpm test
+      - name: Test with coverage
+        run: pnpm test:coverage

--- a/src/lib/services/project-history.test.ts
+++ b/src/lib/services/project-history.test.ts
@@ -374,4 +374,18 @@ describe('getProjectHistory', () => {
     });
     expect(result).toEqual(mockHistory);
   });
+
+  it('returns empty array when no history exists', async () => {
+    mockFindMany.mockResolvedValueOnce([] as never);
+
+    const result = await getProjectHistory('project-nonexistent');
+
+    expect(result).toEqual([]);
+  });
+
+  it('propagates database errors to the caller', async () => {
+    mockFindMany.mockRejectedValueOnce(new Error('DB read failed'));
+
+    await expect(getProjectHistory('project-1')).rejects.toThrow('DB read failed');
+  });
 });

--- a/src/lib/services/project-history.test.ts
+++ b/src/lib/services/project-history.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Project, Kit } from '@prisma/client';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    projectHistory: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  recordProjectHistory,
+  createProjectCreatedHistory,
+  createProjectUpdatedHistory,
+  createProjectDeletedHistory,
+  createKitAddedHistory,
+  createKitRemovedHistory,
+  createKitQuantityUpdatedHistory,
+  getProjectHistory,
+} from './project-history';
+
+const mockCreate = vi.mocked(prisma.projectHistory.create);
+const mockFindMany = vi.mocked(prisma.projectHistory.findMany);
+
+function makePrismaProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'project-1',
+    nom: 'Test Project',
+    status: 'ACTIF',
+    description: null,
+    surfaceManual: null,
+    surfaceOverride: false,
+    createdById: 'user-1',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  };
+}
+
+function makePrismaKit(overrides: Partial<Kit> = {}): Kit {
+  return {
+    id: 'kit-1',
+    nom: 'Test Kit',
+    style: 'modern',
+    description: null,
+    surfaceM2: null,
+    createdById: 'user-1',
+    updatedById: 'user-1',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockResolvedValue(undefined as never);
+});
+
+describe('recordProjectHistory', () => {
+  it('calls prisma.projectHistory.create with JSON-stringified fields', async () => {
+    await recordProjectHistory({
+      userId: 'user-1',
+      projectId: 'project-1',
+      changeType: 'CREATED',
+      description: 'Project created',
+      changedFields: ['nom'],
+      oldValues: { nom: 'Old' },
+      newValues: { nom: 'New' },
+      metadata: { key: 'value' },
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        projectId: 'project-1',
+        changeType: 'CREATED',
+        description: 'Project created',
+        changedFields: JSON.stringify(['nom']),
+        oldValues: JSON.stringify({ nom: 'Old' }),
+        newValues: JSON.stringify({ nom: 'New' }),
+        metadata: JSON.stringify({ key: 'value' }),
+        changedById: 'user-1',
+      },
+    });
+  });
+
+  it('omits optional fields when undefined', async () => {
+    await recordProjectHistory({
+      userId: 'user-1',
+      projectId: 'project-1',
+      changeType: 'DELETED',
+      description: 'Deleted',
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        projectId: 'project-1',
+        changeType: 'DELETED',
+        description: 'Deleted',
+        changedFields: undefined,
+        oldValues: undefined,
+        newValues: undefined,
+        metadata: undefined,
+        changedById: 'user-1',
+      },
+    });
+  });
+
+  it('swallows errors without throwing', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('DB connection failed'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      recordProjectHistory({
+        userId: 'user-1',
+        projectId: 'project-1',
+        changeType: 'CREATED',
+        description: 'Test',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to record project history:',
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('createProjectCreatedHistory', () => {
+  it('records CREATED event with project metadata', async () => {
+    const project = makePrismaProject({ nom: 'My Project', status: 'ACTIF' });
+    await createProjectCreatedHistory('user-1', project);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        projectId: 'project-1',
+        changeType: 'CREATED',
+        description: 'Le projet "My Project" a été créé',
+        metadata: JSON.stringify({
+          projectName: 'My Project',
+          projectStatus: 'ACTIF',
+        }),
+        changedById: 'user-1',
+      }),
+    });
+  });
+});
+
+describe('createProjectUpdatedHistory', () => {
+  it('does not record when no fields changed', async () => {
+    const project: Partial<Project> = { nom: 'Same', status: 'ACTIF', description: 'Desc' };
+    await createProjectUpdatedHistory('user-1', 'project-1', project, project);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('records name change with UPDATED changeType', async () => {
+    await createProjectUpdatedHistory(
+      'user-1',
+      'project-1',
+      { nom: 'Old Name', status: 'ACTIF' } satisfies Partial<Project>,
+      { nom: 'New Name', status: 'ACTIF' } satisfies Partial<Project>
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'UPDATED',
+        description: 'Le nom du projet a été changé de "Old Name" à "New Name"',
+        changedFields: JSON.stringify(['nom']),
+        oldValues: JSON.stringify({ nom: 'Old Name' }),
+        newValues: JSON.stringify({ nom: 'New Name' }),
+      }),
+    });
+  });
+
+  it('records status change with STATUS_CHANGED changeType', async () => {
+    await createProjectUpdatedHistory(
+      'user-1',
+      'project-1',
+      { nom: 'Project', status: 'ACTIF' } satisfies Partial<Project>,
+      { nom: 'Project', status: 'TERMINE' } satisfies Partial<Project>
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'STATUS_CHANGED',
+        description: 'Le statut du projet a été changé de "ACTIF" à "TERMINE"',
+      }),
+    });
+  });
+
+  it('records description change with specific message', async () => {
+    await createProjectUpdatedHistory(
+      'user-1',
+      'project-1',
+      { description: 'Old desc' },
+      { description: 'New desc' }
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'UPDATED',
+        description: 'La description du projet a été modifiée',
+      }),
+    });
+  });
+
+  it('records multiple field changes with generic description', async () => {
+    await createProjectUpdatedHistory(
+      'user-1',
+      'project-1',
+      { nom: 'Old', description: 'Old desc' },
+      { nom: 'New', description: 'New desc' }
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'UPDATED',
+        description: 'Le projet a été modifié (nom, description)',
+      }),
+    });
+  });
+
+  it('uses STATUS_CHANGED when status and other fields change together', async () => {
+    await createProjectUpdatedHistory(
+      'user-1',
+      'project-1',
+      { nom: 'Old', status: 'ACTIF' } satisfies Partial<Project>,
+      { nom: 'New', status: 'TERMINE' } satisfies Partial<Project>
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'STATUS_CHANGED',
+      }),
+    });
+  });
+});
+
+describe('createProjectDeletedHistory', () => {
+  it('records DELETED event with project metadata', async () => {
+    const project = makePrismaProject({ nom: 'Deleted Project' });
+    await createProjectDeletedHistory('user-1', project);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'DELETED',
+        description: 'Le projet "Deleted Project" a été supprimé',
+        metadata: JSON.stringify({
+          projectName: 'Deleted Project',
+          projectStatus: 'ACTIF',
+        }),
+      }),
+    });
+  });
+});
+
+describe('createKitAddedHistory', () => {
+  it('records KIT_ADDED with singular unit label', async () => {
+    const kit = makePrismaKit({ nom: 'Kit A' });
+    await createKitAddedHistory('user-1', 'project-1', kit, 1);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'KIT_ADDED',
+        description: 'Le kit "Kit A" a été ajouté au projet (1 unité)',
+        metadata: JSON.stringify({
+          kitId: 'kit-1',
+          kitName: 'Kit A',
+          kitStyle: 'modern',
+          quantity: 1,
+        }),
+      }),
+    });
+  });
+
+  it('records KIT_ADDED with plural unit label', async () => {
+    const kit = makePrismaKit({ nom: 'Kit B' });
+    await createKitAddedHistory('user-1', 'project-1', kit, 3);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        description: 'Le kit "Kit B" a été ajouté au projet (3 unités)',
+      }),
+    });
+  });
+});
+
+describe('createKitRemovedHistory', () => {
+  it('records KIT_REMOVED event', async () => {
+    const kit = makePrismaKit({ nom: 'Kit C' });
+    await createKitRemovedHistory('user-1', 'project-1', kit, 2);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'KIT_REMOVED',
+        description: 'Le kit "Kit C" a été retiré du projet (2 unités)',
+      }),
+    });
+  });
+
+  it('uses singular label for quantity 1', async () => {
+    const kit = makePrismaKit();
+    await createKitRemovedHistory('user-1', 'project-1', kit, 1);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        description: expect.stringContaining('1 unité)'),
+      }),
+    });
+  });
+});
+
+describe('createKitQuantityUpdatedHistory', () => {
+  it('records quantity change with correct description', async () => {
+    const kit = makePrismaKit({ nom: 'Kit D' });
+    await createKitQuantityUpdatedHistory('user-1', 'project-1', kit, 2, 5);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        changeType: 'KIT_QUANTITY_UPDATED',
+        description: 'La quantité du kit "Kit D" a été modifiée de 2 à 5 unités',
+        metadata: JSON.stringify({
+          kitId: 'kit-1',
+          kitName: 'Kit D',
+          kitStyle: 'modern',
+          oldQuantity: 2,
+          newQuantity: 5,
+        }),
+      }),
+    });
+  });
+
+  it('uses singular label when new quantity is 1', async () => {
+    const kit = makePrismaKit({ nom: 'Kit E' });
+    await createKitQuantityUpdatedHistory('user-1', 'project-1', kit, 3, 1);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        description: 'La quantité du kit "Kit E" a été modifiée de 3 à 1 unité',
+      }),
+    });
+  });
+});
+
+describe('getProjectHistory', () => {
+  it('queries with correct parameters and returns results', async () => {
+    const mockHistory = [
+      { id: 'h-1', changeType: 'CREATED', description: 'Created' },
+    ];
+    mockFindMany.mockResolvedValueOnce(mockHistory as never);
+
+    const result = await getProjectHistory('project-1');
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { projectId: 'project-1' },
+      include: {
+        changedBy: {
+          select: {
+            id: true,
+            name: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(result).toEqual(mockHistory);
+  });
+});

--- a/src/lib/utils/product-helpers.test.ts
+++ b/src/lib/utils/product-helpers.test.ts
@@ -374,6 +374,27 @@ describe('getDefaultProductMode', () => {
     const product = makeProduct();
     expect(getDefaultProductMode(product)).toBe('achat');
   });
+
+  it('returns location when only location data exists (legacy fields nullified)', () => {
+    const product = makeProduct({
+      prixAchat1An: null as unknown as number,
+      prixUnitaire1An: null as unknown as number,
+      prixVente1An: null as unknown as number,
+      prixAchatLocation1An: 50,
+      prixUnitaireLocation1An: 60,
+      prixVenteLocation1An: 60,
+    });
+    expect(getDefaultProductMode(product)).toBe('location');
+  });
+
+  it('returns achat as fallback when neither mode has data (all null)', () => {
+    const product = makeProduct({
+      prixAchat1An: null as unknown as number,
+      prixUnitaire1An: null as unknown as number,
+      prixVente1An: null as unknown as number,
+    });
+    expect(getDefaultProductMode(product)).toBe('achat');
+  });
 });
 
 describe('formatPrice', () => {

--- a/src/lib/utils/project/calculations.test.ts
+++ b/src/lib/utils/project/calculations.test.ts
@@ -6,6 +6,15 @@ import {
   makeProjectKit,
   makeProject,
 } from '../test-fixtures';
+
+function makeOrphanKitProduct(): KitProduct {
+  return {
+    id: 'kp-orphan',
+    kitId: 'kit-1',
+    productId: 'prod-missing',
+    quantite: 1,
+  };
+}
 import {
   calculateProjectPriceTotals,
   calculateProjectPurchaseCosts,
@@ -125,13 +134,7 @@ describe('calculateProjectPurchaseCosts', () => {
   });
 
   it('skips kitProducts without product data', () => {
-    const orphanKitProduct: KitProduct = {
-      id: 'kp-orphan',
-      kitId: 'kit-1',
-      productId: 'prod-missing',
-      quantite: 1,
-    };
-    const kit = makeKit([orphanKitProduct]);
+    const kit = makeKit([makeOrphanKitProduct()]);
     const project = makeProject([makeProjectKit(1, kit)]);
     const costs = calculateProjectPurchaseCosts(project);
     expect(costs).toEqual({ totalPrice: 0, totalCost: 0, totalMargin: 0 });
@@ -296,13 +299,7 @@ describe('calculateEnvironmentalSavings', () => {
   });
 
   it('skips kitProducts without product data', () => {
-    const orphanKitProduct: KitProduct = {
-      id: 'kp-orphan',
-      kitId: 'kit-1',
-      productId: 'prod-missing',
-      quantite: 1,
-    };
-    const kit = makeKit([orphanKitProduct]);
+    const kit = makeKit([makeOrphanKitProduct()]);
     const project = makeProject([makeProjectKit(1, kit)]);
     const savings = calculateEnvironmentalSavings(project);
     expect(savings.rechauffementClimatique).toBe(0);

--- a/src/lib/utils/project/calculations.test.ts
+++ b/src/lib/utils/project/calculations.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import type { Kit } from '@/lib/types/project';
+import type { Kit, KitProduct } from '@/lib/types/project';
 import {
-  makeProduct,
   makeKitProduct,
   makeKit,
   makeProjectKit,
@@ -117,6 +116,26 @@ describe('calculateProjectPurchaseCosts', () => {
     expect(costs.totalCost).toBe(360);
     expect(costs.totalMargin).toBe(240);
   });
+
+  it('skips kits without kitProducts', () => {
+    const kit = { ...makeKit([]), kitProducts: undefined };
+    const project = makeProject([makeProjectKit(1, kit as Kit)]);
+    const costs = calculateProjectPurchaseCosts(project);
+    expect(costs).toEqual({ totalPrice: 0, totalCost: 0, totalMargin: 0 });
+  });
+
+  it('skips kitProducts without product data', () => {
+    const orphanKitProduct: KitProduct = {
+      id: 'kp-orphan',
+      kitId: 'kit-1',
+      productId: 'prod-missing',
+      quantite: 1,
+    };
+    const kit = makeKit([orphanKitProduct]);
+    const project = makeProject([makeProjectKit(1, kit)]);
+    const costs = calculateProjectPurchaseCosts(project);
+    expect(costs).toEqual({ totalPrice: 0, totalCost: 0, totalMargin: 0 });
+  });
 });
 
 describe('calculateProjectRentalCosts', () => {
@@ -148,6 +167,13 @@ describe('calculateProjectRentalCosts', () => {
     const costs3ans = calculateProjectRentalCosts(project, '3ans');
     expect(costs1an.totalPrice).toBe(50);
     expect(costs3ans.totalPrice).toBe(30);
+  });
+
+  it('skips kits without kitProducts', () => {
+    const kit = { ...makeKit([]), kitProducts: undefined };
+    const project = makeProject([makeProjectKit(1, kit as Kit)]);
+    const costs = calculateProjectRentalCosts(project, '1an');
+    expect(costs).toEqual({ totalPrice: 0, totalCost: 0, totalMargin: 0 });
   });
 });
 
@@ -255,6 +281,31 @@ describe('calculateEnvironmentalSavings', () => {
 
     const savings = calculateEnvironmentalSavings(project);
     expect(savings.rechauffementClimatique).toBe(5);
+  });
+
+  it('skips kits without kitProducts', () => {
+    const kit = { ...makeKit([]), kitProducts: undefined };
+    const project = makeProject([makeProjectKit(1, kit as Kit)]);
+    const savings = calculateEnvironmentalSavings(project);
+    expect(savings).toEqual({
+      rechauffementClimatique: 0,
+      epuisementRessources: 0,
+      acidification: 0,
+      eutrophisation: 0,
+    });
+  });
+
+  it('skips kitProducts without product data', () => {
+    const orphanKitProduct: KitProduct = {
+      id: 'kp-orphan',
+      kitId: 'kit-1',
+      productId: 'prod-missing',
+      quantite: 1,
+    };
+    const kit = makeKit([orphanKitProduct]);
+    const project = makeProject([makeProjectKit(1, kit)]);
+    const savings = calculateEnvironmentalSavings(project);
+    expect(savings.rechauffementClimatique).toBe(0);
   });
 });
 

--- a/src/lib/utils/project/status.test.ts
+++ b/src/lib/utils/project/status.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { ProjectStatus } from '@/lib/types/project';
+import { getStatusConfig, getStatusColor, getStatusIcon } from './status';
+
+describe('getStatusConfig', () => {
+  it('returns green config for ACTIF', () => {
+    const config = getStatusConfig(ProjectStatus.ACTIF);
+    expect(config.color).toBe('bg-green-100 text-green-800');
+    expect(config.icon).toBe('🟢');
+  });
+
+  it('returns blue config for TERMINE', () => {
+    const config = getStatusConfig(ProjectStatus.TERMINE);
+    expect(config.color).toBe('bg-blue-100 text-blue-800');
+    expect(config.icon).toBe('🔵');
+  });
+
+  it('returns yellow config for EN_PAUSE', () => {
+    const config = getStatusConfig(ProjectStatus.EN_PAUSE);
+    expect(config.color).toBe('bg-yellow-100 text-yellow-800');
+    expect(config.icon).toBe('🟡');
+  });
+
+  it('returns gray config for ARCHIVE', () => {
+    const config = getStatusConfig(ProjectStatus.ARCHIVE);
+    expect(config.color).toBe('bg-gray-100 text-gray-800');
+    expect(config.icon).toBe('⚫');
+  });
+
+  it('returns default config for unknown status', () => {
+    const config = getStatusConfig('UNKNOWN_STATUS');
+    expect(config.color).toBe('bg-gray-100 text-gray-800');
+    expect(config.icon).toBe('⚪');
+  });
+});
+
+describe('getStatusColor', () => {
+  it('returns color classes for known status', () => {
+    expect(getStatusColor(ProjectStatus.ACTIF)).toBe('bg-green-100 text-green-800');
+  });
+
+  it('returns default color for unknown status', () => {
+    expect(getStatusColor('INVALID')).toBe('bg-gray-100 text-gray-800');
+  });
+});
+
+describe('getStatusIcon', () => {
+  it('returns icon for known status', () => {
+    expect(getStatusIcon(ProjectStatus.ACTIF)).toBe('🟢');
+  });
+
+  it('returns default icon for unknown status', () => {
+    expect(getStatusIcon('INVALID')).toBe('⚪');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
         'src/lib/utils/product-helpers.ts',
         'src/lib/utils/kit/calculations.ts',
         'src/lib/utils/project/calculations.ts',
+        'src/lib/utils/project/status.ts',
+        'src/lib/services/project-history.ts',
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## Summary

Add 34 new unit tests across 2 new test files and 2 existing ones, bringing the total from 91 to 125 tests. This establishes a regression safety net before upcoming refactors (component splitting, service layer extraction, duplication elimination). Coverage now sits at 98.59% statements / 97.47% branches across all targeted files.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Other

## Changes Overview

### New test files
- `src/lib/services/project-history.test.ts` — 18 tests with Prisma mocking for all 8 exported functions (history recording, CRUD events, kit operations, error swallowing)
- `src/lib/utils/project/status.test.ts` — 9 tests for `getStatusConfig`, `getStatusColor`, `getStatusIcon` with all 4 statuses + fallback

### Coverage gap fixes
- `src/lib/utils/product-helpers.test.ts` — 2 tests covering `getDefaultProductMode` branches (location-only data, no data at all)
- `src/lib/utils/project/calculations.test.ts` — 5 tests covering `calculateCostsForMode` and `calculateEnvironmentalSavings` guards (kits without kitProducts, kitProducts without product data)

### Configuration
- `vitest.config.ts` — added `project-history.ts` and `status.ts` to coverage scope
- `.github/workflows/ci.yml` — upgraded from `pnpm test` to `pnpm test:coverage` so 80% thresholds gate PRs

## Technical Details

**Files Changed:** 6 files (+510 lines)
**Main Areas:**
- `src/lib/services/` — new test file with `vi.mock` for `server-only` and `@/lib/db`
- `src/lib/utils/project/` — new status tests + coverage gap fixes in calculations
- `src/lib/utils/` — coverage gap fixes in product-helpers

## Testing

- [x] `pnpm test` — 125 tests pass
- [x] `pnpm test:coverage` — all thresholds met (98.59% stmts, 97.47% branches, 100% funcs/lines)
- [x] `pnpm lint` — no new warnings
- [x] `pnpm type-check` — passes
- [x] `pnpm build` — passes

## Breaking Changes

None

## Deployment Notes

No special steps required.

Closes TRI-53