### PR TITLE
refactor: replace all console.* with structured logger (TRI-50)

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -5,6 +5,7 @@ import { UsersList } from '@/components/admin/users-list'
 import { RoleGuard } from '@/components/auth/role-guard'
 import { UserRole } from '@/lib/types/user'
 import { useDialog } from '@/components/providers/dialog-provider'
+import { logger } from '@/lib/logger'
 import { Card, CardContent } from '@/components/ui/card'
 import { Shield, Loader2 } from 'lucide-react'
 
@@ -45,7 +46,7 @@ export default function AdminPage() {
       const usersData = await response.json()
       setUsers(usersData)
     } catch (error) {
-      console.error('Erreur lors du chargement des utilisateurs:', error)
+      logger.error('Error loading users', { error })
       await showError(
         'Erreur',
         error instanceof Error
@@ -79,7 +80,7 @@ export default function AdminPage() {
 
       await showSuccess('Succès', "Le rôle de l'utilisateur a été mis à jour avec succès")
     } catch (error) {
-      console.error('Erreur lors de la mise à jour du rôle:', error)
+      logger.error('Error updating user role', { error })
       await showError(
         'Erreur',
         error instanceof Error

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSession, signOut } from '@/lib/auth-client'
 import { useRouter } from 'next/navigation'
+import { logger } from '@/lib/logger'
 import { useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -102,7 +103,7 @@ export default function DashboardPage() {
                       router.push('/auth/connexion')
                       router.refresh()
                     } catch (error) {
-                      console.error('Sign out error:', error)
+                      logger.error('Sign out error', { error })
                     }
                   }}
                   variant="outline"

--- a/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ProjectDetail } from '@/components/projects/project-detail'
 import { ProjectDetailSkeleton } from '@/components/projects/project-detail-skeleton'
 import { notFound, useParams } from 'next/navigation'
 import { Project } from '@/lib/types/project'
+import { logger } from '@/lib/logger'
 
 function ProjectContent() {
   const params = useParams()
@@ -29,7 +30,7 @@ function ProjectContent() {
       setProject(data)
       setError(false)
     } catch (error) {
-      console.error('Erreur lors du chargement du projet:', error)
+      logger.error('Error loading project', { error })
       setError(true)
     } finally {
       setLoading(false)

--- a/src/app/api/auth/get-session/route.ts
+++ b/src/app/api/auth/get-session/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@/lib/auth'
 import { NextRequest } from 'next/server'
+import { logger } from '@/lib/logger'
 
 // Force cette route à être dynamique
 export const dynamic = 'force-dynamic'
@@ -16,7 +17,7 @@ export async function GET(request: NextRequest) {
 
     return Response.json({ user: session.user }, { status: 200 })
   } catch (error) {
-    console.error('Session check error:', error)
+    logger.error('Session check error', { error })
     return Response.json({ user: null }, { status: 200 })
   }
 }

--- a/src/components/admin/users-list.tsx
+++ b/src/components/admin/users-list.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/dialog'
 import { User, Calendar, Package, FolderOpen, Users, Settings } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { logger } from '@/lib/logger'
 import { UserRole } from '@/lib/types/user'
 
 interface UserStats {
@@ -82,7 +83,7 @@ export function UsersList({ users, onRoleUpdate }: UsersListProps) {
       setIsRoleDialogOpen(false)
       setSelectedUser(null)
     } catch (error) {
-      console.error('Erreur lors de la mise à jour du rôle:', error)
+      logger.error('Error updating user role', { error })
     } finally {
       setIsUpdating(false)
     }

--- a/src/components/auth/google-button.tsx
+++ b/src/components/auth/google-button.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Loader2 } from 'lucide-react'
 import { signIn } from '@/lib/auth-client'
 import { getSpecificAuthError } from '@/lib/auth/error-messages'
+import { logger } from '@/lib/logger'
 
 interface GoogleButtonProps {
   text?: string
@@ -24,7 +25,7 @@ export function GoogleButton({ text = 'Continuer avec Google', onError }: Google
       })
       // Ne pas mettre setIsLoading(false) ici car la page va être redirigée
     } catch (err) {
-      console.error('🔴 Google sign-in error:', err)
+      logger.error('Google sign-in error', { error: err })
       const errorMessage = getSpecificAuthError(err, 'google')
       onError?.(errorMessage)
       setIsLoading(false)

--- a/src/components/headers/dashboard-header.tsx
+++ b/src/components/headers/dashboard-header.tsx
@@ -28,6 +28,7 @@ import {
   Shield,
 } from 'lucide-react'
 import { useState } from 'react'
+import { logger } from '@/lib/logger'
 import { useSession, signOut } from '@/lib/auth-client'
 import { usePathname, useRouter } from 'next/navigation'
 import { useUser } from '@/components/providers/user-provider'
@@ -58,7 +59,7 @@ export function DashboardHeader() {
       router.push('/auth/connexion')
       router.refresh()
     } catch (error) {
-      console.error('Sign out error:', error)
+      logger.error('Sign out error', { error })
     }
   }
 

--- a/src/components/kits/form-sections/kit-products-section.tsx
+++ b/src/components/kits/form-sections/kit-products-section.tsx
@@ -20,6 +20,7 @@ import {
   Leaf,
   Square,
 } from 'lucide-react'
+import { logger } from '@/lib/logger'
 import { KitFormData } from '@/lib/schemas/kit'
 import { ProductSelectionGrid } from '../product-selection/ProductSelectionGrid'
 import { Product } from '@/lib/types/project'
@@ -63,7 +64,7 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
         const productsArray = data.products || data
         setProducts(productsArray)
       } catch (error) {
-        console.error('Erreur:', error)
+        logger.error('Error loading products', { error })
         onError('Impossible de charger la liste des produits')
       } finally {
         setIsLoadingProducts(false)

--- a/src/components/kits/kit-card.tsx
+++ b/src/components/kits/kit-card.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/utils/product-helpers'
 
 // Utiliser le type Kit complet du system
+import { logger } from '@/lib/logger'
 import { type Kit } from '@/lib/types/project'
 
 interface KitCardProps {
@@ -132,7 +133,7 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
     try {
       await onDelete(kit.id)
     } catch (err) {
-      console.error('Erreur:', err)
+      logger.error('Error deleting kit', { error: err })
     }
   }
 

--- a/src/components/kits/kit-form.tsx
+++ b/src/components/kits/kit-form.tsx
@@ -7,6 +7,7 @@ import { kitSchema, type KitFormData } from '@/lib/schemas/kit'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Accordion } from '@/components/ui/accordion'
 import { useSession } from '@/lib/auth-client'
+import { logger } from '@/lib/logger'
 
 // Import des sections
 import { KitGeneralInfoSection } from './form-sections/kit-general-info-section'
@@ -103,7 +104,7 @@ export function KitForm({ initialData, kitId }: KitFormProps) {
 
       router.push('/kits?updated=' + Date.now())
     } catch (err) {
-      console.error('[KitForm] Error submitting form:', err)
+      logger.error('[KitForm] Error submitting form', { error: err })
       setError(err instanceof Error ? err.message : "Une erreur inattendue s'est produite")
     } finally {
       setIsLoading(false)

--- a/src/components/kits/kits-list-wrapper.tsx
+++ b/src/components/kits/kits-list-wrapper.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { KitsGridClient } from '@/components/kits/kits-grid-client'
 import { type Kit } from '@/lib/types/project'
+import { logger } from '@/lib/logger'
 
 interface KitsListWrapperProps {
   initialKits: Kit[]
@@ -30,7 +31,7 @@ export function KitsListWrapper({ initialKits }: KitsListWrapperProps) {
         const updatedKits = kits.filter((k) => k.id !== kitId)
         setKits(updatedKits)
       } catch (err) {
-        console.error('[KitsListWrapper] Error deleting kit:', err)
+        logger.error('[KitsListWrapper] Error deleting kit', { error: err })
       }
     },
     [kits],

--- a/src/components/products/products-list-wrapper.tsx
+++ b/src/components/products/products-list-wrapper.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Package2, Search, X, Image, ImageOff } from 'lucide-react'
 import { type Product } from '@/lib/types/project'
 import { useDebounce } from '@/hooks/use-debounce'
+import { logger } from '@/lib/logger'
 
 interface ProductsListWrapperProps {
   initialProducts: Product[]
@@ -48,7 +49,7 @@ function ProductsListContent({ initialProducts }: ProductsListWrapperProps) {
         const updatedProducts = products.filter((p) => p.id !== productId)
         setProducts(updatedProducts)
       } catch (err) {
-        console.error('[ProductsListWrapper] Error deleting product:', err)
+        logger.error('[ProductsListWrapper] Error deleting product', { error: err })
       }
     },
     [products],

--- a/src/components/projects/create-project-modal.tsx
+++ b/src/components/projects/create-project-modal.tsx
@@ -22,6 +22,7 @@ import {
 import { Target, Save } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useDialog } from '@/components/providers/dialog-provider'
+import { logger } from '@/lib/logger'
 
 interface CreateProjectModalProps {
   isOpen: boolean
@@ -64,7 +65,7 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
         throw new Error(errorData.error || 'Erreur lors de la création du projet')
       }
     } catch (error) {
-      console.error('Erreur:', error)
+      logger.error('Error creating project', { error })
       await showError(
         'Erreur de création',
         error instanceof Error ? error.message : "Une erreur inattendue s'est produite",

--- a/src/components/projects/edit-project-dialog.tsx
+++ b/src/components/projects/edit-project-dialog.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
 import { X, Edit3, Loader2 } from 'lucide-react'
+import { logger } from '@/lib/logger'
 import { Project, ProjectStatus } from '@/lib/types/project'
 
 interface EditProjectDialogProps {
@@ -88,7 +89,7 @@ export function EditProjectDialog({
       onSuccess('Le projet a été mis à jour avec succès')
       onClose()
     } catch (error) {
-      console.error('Erreur lors de la mise à jour du projet:', error)
+      logger.error('Error updating project', { error })
       onError('Une erreur est survenue lors de la mise à jour du projet')
     } finally {
       setIsLoading(false)

--- a/src/components/projects/project-edit-form.tsx
+++ b/src/components/projects/project-edit-form.tsx
@@ -18,6 +18,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { ArrowLeft, Save, Trash2, Edit3, Package, Leaf, Euro } from 'lucide-react'
 import Link from 'next/link'
+import { logger } from '@/lib/logger'
 import { type Project } from '@/lib/types/project'
 
 type ProjectEditData = Pick<Project, 'id' | 'nom' | 'status'> &
@@ -71,7 +72,7 @@ export function ProjectEditForm({ project }: ProjectEditFormProps) {
         throw new Error('Erreur lors de la modification du projet')
       }
     } catch (error) {
-      console.error('Erreur:', error)
+      logger.error('Error updating project', { error })
     } finally {
       setIsLoading(false)
     }

--- a/src/components/projects/projects-grid.tsx
+++ b/src/components/projects/projects-grid.tsx
@@ -7,6 +7,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { FolderOpen } from 'lucide-react'
 import { CreateProjectButton } from './create-project-button'
 import { useSearchParams } from 'next/navigation'
+import { logger } from '@/lib/logger'
 
 interface ProjectsGridProps {
   projects?: Project[]
@@ -36,7 +37,7 @@ export function ProjectsGrid({ projects, selectedUserId }: ProjectsGridProps) {
         setLocalProjects(data)
       }
     } catch (error) {
-      console.error('Erreur lors du chargement des projets:', error)
+      logger.error('Error loading projects', { error })
     } finally {
       setIsLoading(false)
     }

--- a/src/components/projects/projects-list-wrapper.tsx
+++ b/src/components/projects/projects-list-wrapper.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { FolderOpen } from 'lucide-react'
 import { type Project } from '@/lib/types/project'
+import { logger } from '@/lib/logger'
 
 interface ProjectsListWrapperProps {
   initialProjects: Project[]
@@ -33,7 +34,7 @@ function ProjectsListContent({ initialProjects }: ProjectsListWrapperProps) {
         const updatedProjects = projects.filter((p) => p.id !== projectId)
         setProjects(updatedProjects)
       } catch (err) {
-        console.error('[ProjectsListWrapper] Error deleting project:', err)
+        logger.error('[ProjectsListWrapper] Error deleting project', { error: err })
       }
     },
     [projects],

--- a/src/components/projects/user-selector.tsx
+++ b/src/components/projects/user-selector.tsx
@@ -13,6 +13,7 @@ import { UserRole } from '@/lib/types/user'
 import { User } from 'lucide-react'
 import { useSession } from '@/lib/auth-client'
 import { useRouter } from 'next/navigation'
+import { logger } from '@/lib/logger'
 
 interface SimpleUser {
   id: string
@@ -46,7 +47,7 @@ export function UserSelector({ onUserChange, selectedUserId }: UserSelectorProps
         setUsers(data)
       }
     } catch (error) {
-      console.error('Erreur lors du chargement des utilisateurs:', error)
+      logger.error('Error loading users', { error })
     } finally {
       setLoading(false)
     }

--- a/src/components/providers/user-provider.tsx
+++ b/src/components/providers/user-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { useSession } from '@/lib/auth-client'
+import { logger } from '@/lib/logger'
 
 interface UserData {
   id: string
@@ -52,7 +53,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
             })
           }
         } catch (error) {
-          console.error('Error fetching user profile:', error)
+          logger.error('Error fetching user profile', { error })
           // Fallback to session data if error occurs
           setUser({
             id: session.user.id,
@@ -92,7 +93,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         }
       }
     } catch (error) {
-      console.error('Error refreshing user:', error)
+      logger.error('Error refreshing user', { error })
     }
   }
 

--- a/src/components/ui/delete-confirm-dialog.tsx
+++ b/src/components/ui/delete-confirm-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Trash2, AlertTriangle } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { logger } from '@/lib/logger'
 
 interface DeleteConfirmDialogProps {
   title?: string
@@ -48,7 +49,7 @@ export function DeleteConfirmDialog({
       await onConfirm()
       setOpen(false)
     } catch (error) {
-      console.error('Erreur lors de la suppression:', error)
+      logger.error('Error during deletion', { error })
     } finally {
       setIsDeleting(false)
     }

--- a/src/features/pdf/project-pdf-download-button.tsx
+++ b/src/features/pdf/project-pdf-download-button.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react'
 import { Download, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { logger } from '@/lib/logger'
 import type { Project } from '@/lib/types/project'
 
 interface ProjectPdfDownloadButtonProps {
@@ -29,7 +30,7 @@ export function ProjectPdfDownloadButton({ project }: ProjectPdfDownloadButtonPr
       document.body.removeChild(link)
       URL.revokeObjectURL(url)
     } catch (error) {
-      console.error('PDF generation failed:', error)
+      logger.error('PDF generation failed', { error })
     } finally {
       setIsGenerating(false)
     }

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -1,5 +1,6 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
+import { logger } from '@/lib/logger'
 
 /**
  * Get the current user session in a Server Component
@@ -13,7 +14,7 @@ export async function getUserSession() {
     })
     return session
   } catch (error) {
-    console.error('Error getting user session:', error)
+    logger.error('Error getting user session', { error })
     return null
   }
 }

--- a/src/lib/auth/sign-in-action.ts
+++ b/src/lib/auth/sign-in-action.ts
@@ -1,4 +1,5 @@
 import { signIn } from '@/lib/auth-client'
+import { logger } from '@/lib/logger'
 
 export const signInSocialAction = async ({ provider }: { provider: 'google' }) => {
   try {
@@ -7,6 +8,6 @@ export const signInSocialAction = async ({ provider }: { provider: 'google' }) =
       callbackURL: '/dashboard',
     })
   } catch (error) {
-    console.error('Sign in error:', error)
+    logger.error('Sign in error', { error })
   }
 }

--- a/src/lib/services/project-history.test.ts
+++ b/src/lib/services/project-history.test.ts
@@ -123,7 +123,9 @@ describe('recordProjectHistory', () => {
       }),
     ).resolves.toBeUndefined()
 
-    expect(consoleSpy).toHaveBeenCalledWith('Failed to record project history:', expect.any(Error))
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to record project history'),
+    )
     consoleSpy.mockRestore()
   })
 })

--- a/src/lib/services/project-history.ts
+++ b/src/lib/services/project-history.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/db'
 import { ProjectChangeType, Project, Kit } from '@prisma/client'
+import { logger } from '@/lib/logger'
 
 export interface ProjectHistoryContext {
   userId: string
@@ -30,7 +31,7 @@ export async function recordProjectHistory(context: ProjectHistoryContext) {
       },
     })
   } catch (error) {
-    console.error('Failed to record project history:', error)
+    logger.error('Failed to record project history', { error })
     // Don't throw - history recording should not break main operations
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -55,7 +56,7 @@ export default async function middleware(request: NextRequest) {
 
     return NextResponse.next()
   } catch (error) {
-    console.error('Middleware error:', error)
+    logger.error('Middleware error', { error })
     // If session check fails, allow access to public routes only
     if (!isPublicRoute) {
       return NextResponse.redirect(new URL('/auth/connexion', request.url))


### PR DESCRIPTION
## Summary
- Replace all `console.error`/`console.log`/`console.warn` calls across 25 files with the existing `logger` utility (`src/lib/logger.ts`)
- Error context is now passed as structured objects (`{ error }`) instead of loose arguments
- French error messages translated to English
- Only `src/lib/logger.ts` retains `console.*` calls (by design)

## Changes
- 25 files modified: added `import { logger } from '@/lib/logger'` and replaced `console.*` calls
- Zero `console.*` remaining outside of `logger.ts`

## Test plan
- [x] `pnpm build` passes without errors
- [x] `pnpm lint` passes
- [x] Grep confirms zero `console.*` outside logger.ts

Closes TRI-50