### PR TITLE
fix(projects): format price/m² with 2 decimal places

### DIFF
--- a/src/components/projects/project-overview-tab.tsx
+++ b/src/components/projects/project-overview-tab.tsx
@@ -165,20 +165,27 @@ export function ProjectOverviewTab({
                 {pricingMode === 'location' ? (
                   <>
                     <p className="text-lg font-bold text-green-800">
-                      {Math.round(
-                        annualToMonthly(currentPrice) / project.totalSurface,
-                      ).toLocaleString('fr-FR')}
+                      {(annualToMonthly(currentPrice) / project.totalSurface).toLocaleString(
+                        'fr-FR',
+                        { minimumFractionDigits: 2, maximumFractionDigits: 2 },
+                      )}
                       €/m²
                       <span className="ml-1 text-xs font-normal text-green-600">/mois</span>
                     </p>
                     <p className="text-xs text-green-600">
-                      {Math.round(currentPrice / project.totalSurface).toLocaleString('fr-FR')}
+                      {(currentPrice / project.totalSurface).toLocaleString('fr-FR', {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
                       €/m² /an
                     </p>
                   </>
                 ) : (
                   <p className="text-lg font-bold text-green-800">
-                    {Math.round(currentPrice / project.totalSurface).toLocaleString('fr-FR')}
+                    {(currentPrice / project.totalSurface).toLocaleString('fr-FR', {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
                     €/m²
                   </p>
                 )}


### PR DESCRIPTION
## Summary

- Format all price/m² values with exactly 2 decimal places in the project overview tab
- The sidebar "Aperçu financier" already had correct formatting; the top card used `Math.round()` producing inconsistent display (e.g., `1€/m²` instead of `1,00€/m²`)

## Related Issue

TRI-69

## Changes

- **`src/components/projects/project-overview-tab.tsx`**: Replace `Math.round(...).toLocaleString('fr-FR')` with `.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })` in 3 places:
  - Monthly price/m² (location mode)
  - Annual price/m² (location mode)
  - Price/m² (achat mode)

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [ ] Unit tests pass
- [x] Manual testing done

## Screenshots (if UI changes)

<!-- Prices now consistently show 2 decimals: "1,00€/m²/mois" and "106,00€/m²/an" -->
