### PR TITLE
fix(ui): clarify that rental prices are monthly across products and kits

### DIFF
--- a/src/components/kits/form-sections/kit-products-section.tsx
+++ b/src/components/kits/form-sections/kit-products-section.tsx
@@ -353,7 +353,9 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
                                     <div className="border-primary/20 space-y-0.5 border-l-2 pl-4">
                                       <div className="flex items-center gap-1 text-xs">
                                         <Home className="text-primary h-3 w-3" />
-                                        <span className="text-muted-foreground">Loc. 1an:</span>
+                                        <span className="text-muted-foreground">
+                                          Loc. 1an /mois:
+                                        </span>
                                         {pricingLocation1An.prixVente &&
                                         pricingLocation1An.prixVente > 0 ? (
                                           <span className="text-primary font-semibold">
@@ -370,7 +372,9 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
 
                                       <div className="flex items-center gap-1 text-xs">
                                         <Home className="text-primary h-3 w-3" />
-                                        <span className="text-muted-foreground">Loc. 2ans:</span>
+                                        <span className="text-muted-foreground">
+                                          Loc. 2ans /mois:
+                                        </span>
                                         {pricingLocation2Ans.prixVente &&
                                         pricingLocation2Ans.prixVente > 0 ? (
                                           <span className="text-primary font-semibold">
@@ -387,7 +391,9 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
 
                                       <div className="flex items-center gap-1 text-xs">
                                         <Home className="text-primary h-3 w-3" />
-                                        <span className="text-muted-foreground">Loc. 3ans:</span>
+                                        <span className="text-muted-foreground">
+                                          Loc. 3ans /mois:
+                                        </span>
                                         {pricingLocation3Ans.prixVente &&
                                         pricingLocation3Ans.prixVente > 0 ? (
                                           <span className="text-primary font-semibold">
@@ -515,7 +521,9 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
                   <div className="border-primary/10 rounded-lg border bg-white/60 p-4">
                     <div className="grid grid-cols-3 gap-4">
                       <div className="text-center">
-                        <p className="text-muted-foreground mb-1 text-xs font-medium">Prix 1 an</p>
+                        <p className="text-muted-foreground mb-1 text-xs font-medium">
+                          Prix 1 an /mois
+                        </p>
                         <p className="text-primary text-xl font-bold">
                           {formatPrice(totals.totalLocation1An)}
                         </p>
@@ -523,7 +531,7 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
                       {totals.totalLocation2Ans > 0 && (
                         <div className="text-center">
                           <p className="text-muted-foreground mb-1 text-xs font-medium">
-                            Prix 2 ans
+                            Prix 2 ans /mois
                           </p>
                           <p className="text-primary text-xl font-bold">
                             {formatPrice(totals.totalLocation2Ans)}
@@ -533,7 +541,7 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
                       {totals.totalLocation3Ans > 0 && (
                         <div className="text-center">
                           <p className="text-muted-foreground mb-1 text-xs font-medium">
-                            Prix 3 ans
+                            Prix 3 ans /mois
                           </p>
                           <p className="text-primary text-xl font-bold">
                             {formatPrice(totals.totalLocation3Ans)}

--- a/src/components/kits/kit-card.tsx
+++ b/src/components/kits/kit-card.tsx
@@ -266,19 +266,19 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
             </div>
             <div className="grid grid-cols-3 gap-2">
               <div className="from-primary/5 to-primary/10 border-primary/20 rounded-lg border bg-gradient-to-br p-3">
-                <div className="text-primary/70 mb-1 text-xs font-medium">1 an</div>
+                <div className="text-primary/70 mb-1 text-xs font-medium">1 an /mois</div>
                 <div className="text-primary text-sm font-bold">
                   {formatPrice(totalPriceLocation1An)}
                 </div>
               </div>
               <div className="from-primary/5 to-primary/10 border-primary/20 rounded-lg border bg-gradient-to-br p-3">
-                <div className="text-primary/70 mb-1 text-xs font-medium">2 ans</div>
+                <div className="text-primary/70 mb-1 text-xs font-medium">2 ans /mois</div>
                 <div className="text-primary text-sm font-bold">
                   {formatPrice(totalPriceLocation2Ans)}
                 </div>
               </div>
               <div className="from-primary/5 to-primary/10 border-primary/20 rounded-lg border bg-gradient-to-br p-3">
-                <div className="text-primary/70 mb-1 text-xs font-medium">3 ans</div>
+                <div className="text-primary/70 mb-1 text-xs font-medium">3 ans /mois</div>
                 <div className="text-primary text-sm font-bold">
                   {formatPrice(totalPriceLocation3Ans)}
                 </div>

--- a/src/components/products/form-sections/pricing-environmental-section.tsx
+++ b/src/components/products/form-sections/pricing-environmental-section.tsx
@@ -334,7 +334,7 @@ export function PricingEnvironmentalSection({
             <div className="mb-4 flex items-center justify-between">
               <h4 className="flex items-center gap-2 font-semibold text-gray-900">
                 <div className="h-2 w-2 rounded-full bg-[#30C1BD]"></div>
-                Tarification 1 an * - Location
+                Tarification 1 an (mensuel) * - Location
               </h4>
               {watchedValues.prixAchatLocation1An && watchedValues.prixUnitaireLocation1An && (
                 <span className="text-sm font-medium text-green-600">
@@ -395,7 +395,7 @@ export function PricingEnvironmentalSection({
               </div>
 
               <div className="space-y-2">
-                <Label className="text-sm font-medium text-gray-700">Prix total</Label>
+                <Label className="text-sm font-medium text-gray-700">Prix total /mois</Label>
                 <div className="relative">
                   <Input
                     type="number"
@@ -425,7 +425,7 @@ export function PricingEnvironmentalSection({
             <div className="mb-4 flex items-center justify-between">
               <h4 className="flex items-center gap-2 font-semibold text-gray-900">
                 <div className="h-2 w-2 rounded-full bg-gray-400"></div>
-                Tarification 2 ans (optionnel) - Location
+                Tarification 2 ans (mensuel, optionnel) - Location
               </h4>
               {watchedValues.prixAchatLocation2Ans && watchedValues.prixUnitaireLocation2Ans && (
                 <span className="text-sm font-medium text-green-600">
@@ -486,7 +486,7 @@ export function PricingEnvironmentalSection({
               </div>
 
               <div className="space-y-2">
-                <Label className="text-sm font-medium text-gray-700">Prix total</Label>
+                <Label className="text-sm font-medium text-gray-700">Prix total /mois</Label>
                 <div className="relative">
                   <Input
                     type="number"
@@ -516,7 +516,7 @@ export function PricingEnvironmentalSection({
             <div className="mb-4 flex items-center justify-between">
               <h4 className="flex items-center gap-2 font-semibold text-gray-900">
                 <div className="h-2 w-2 rounded-full bg-gray-400"></div>
-                Tarification 3 ans (optionnel) - Location
+                Tarification 3 ans (mensuel, optionnel) - Location
               </h4>
               {watchedValues.prixAchatLocation3Ans && watchedValues.prixUnitaireLocation3Ans && (
                 <span className="text-sm font-medium text-green-600">
@@ -577,7 +577,7 @@ export function PricingEnvironmentalSection({
               </div>
 
               <div className="space-y-2">
-                <Label className="text-sm font-medium text-gray-700">Prix total</Label>
+                <Label className="text-sm font-medium text-gray-700">Prix total /mois</Label>
                 <div className="relative">
                   <Input
                     type="number"

--- a/src/components/products/product-card/ProductCardPricing.tsx
+++ b/src/components/products/product-card/ProductCardPricing.tsx
@@ -46,13 +46,13 @@ export function ProductCardPricing({ product, className }: ProductCardPricingPro
       <div>
         <div className="mb-3 flex items-center gap-2">
           <div className="h-2 w-2 rounded-full bg-emerald-500" />
-          <span className="text-foreground text-sm font-medium">Prix de location</span>
+          <span className="text-foreground text-sm font-medium">Prix de location (mensuel)</span>
         </div>
 
         <div className="grid grid-cols-3 gap-2">
           {/* 1 an */}
           <div className="rounded-lg border border-emerald-200/50 bg-gradient-to-br from-emerald-50 to-emerald-100/50 p-3">
-            <div className="mb-1 text-xs font-medium text-emerald-700">1 an</div>
+            <div className="mb-1 text-xs font-medium text-emerald-700">1 an /mois</div>
             <div className="text-sm font-semibold text-emerald-800">
               {rental1Year.prixVente && rental1Year.prixVente > 0 ? (
                 formatPrice(rental1Year.prixVente)
@@ -64,7 +64,7 @@ export function ProductCardPricing({ product, className }: ProductCardPricingPro
 
           {/* 2 ans */}
           <div className="rounded-lg border border-emerald-200/50 bg-gradient-to-br from-emerald-50 to-emerald-100/50 p-3">
-            <div className="mb-1 text-xs font-medium text-emerald-700">2 ans</div>
+            <div className="mb-1 text-xs font-medium text-emerald-700">2 ans /mois</div>
             <div className="text-sm font-semibold text-emerald-800">
               {rental2Years.prixVente && rental2Years.prixVente > 0 ? (
                 formatPrice(rental2Years.prixVente)
@@ -76,7 +76,7 @@ export function ProductCardPricing({ product, className }: ProductCardPricingPro
 
           {/* 3 ans */}
           <div className="rounded-lg border border-emerald-200/50 bg-gradient-to-br from-emerald-50 to-emerald-100/50 p-3">
-            <div className="mb-1 text-xs font-medium text-emerald-700">3 ans</div>
+            <div className="mb-1 text-xs font-medium text-emerald-700">3 ans /mois</div>
             <div className="text-sm font-semibold text-emerald-800">
               {rental3Years.prixVente && rental3Years.prixVente > 0 ? (
                 formatPrice(rental3Years.prixVente)


### PR DESCRIPTION
## Summary

- Clarify that all rental (location) prices displayed across the platform are **monthly** prices
- Add "/mois" or "(mensuel)" indicators to rental price labels in product cards, kit cards, kit product sections, and product pricing forms

## Related Issue

TRI-68

## Changes

- **Product form** (`pricing-environmental-section.tsx`): Updated rental section headers to include "(mensuel)" and "Prix total" labels to "/mois"
- **Product card** (`ProductCardPricing.tsx`): Added "(mensuel)" to rental price header and "/mois" to period labels
- **Kit card** (`kit-card.tsx`): Added "/mois" to 1an/2ans/3ans rental price labels
- **Kit products section** (`kit-products-section.tsx`): Added "/mois" to individual product rental prices and kit rental totals

## Test Plan

- [x] Lint passes
- [x] Manual testing done
- [ ] Unit tests pass (no test runner configured)

## Screenshots (if UI changes)

All rental price labels now display "/mois" to indicate monthly pricing.
