### PR TITLE
feat(pricing): implement cascade break-even algorithm and extended rental pricing

### DIFF
--- a/src/components/projects/purchase-rental-comparison.tsx
+++ b/src/components/projects/purchase-rental-comparison.tsx
@@ -49,7 +49,8 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
   const rental2Years = calculateProjectRentalCosts(project, '2ans')
   const rental3Years = calculateProjectRentalCosts(project, '3ans')
 
-  const breakEvenPoint = calculateBreakEvenPoint(project)
+  const breakEvenResult = calculateBreakEvenPoint(project)
+  const breakEvenYears = breakEvenResult?.breakEvenYears ?? null
 
   const getRentalDataForHorizon = (years: number) => {
     if (years <= 1) return rental1Year
@@ -176,7 +177,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                   <CardTitle className="text-xl text-green-900">Achat</CardTitle>
                 </div>
-                {!isRentalBetter && breakEvenPoint && selectedTimeHorizon > breakEvenPoint && (
+                {!isRentalBetter && breakEvenYears && selectedTimeHorizon > breakEvenYears && (
                   <Badge className="bg-green-500 text-white">Recommandé</Badge>
                 )}
               </div>
@@ -262,7 +263,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                   <CardTitle className="text-xl text-blue-900">Location</CardTitle>
                 </div>
-                {isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint && (
+                {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears && (
                   <Badge className="bg-blue-500 text-white">Recommandé</Badge>
                 )}
               </div>
@@ -354,7 +355,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
       </div>
 
       {/* Break-Even Analysis */}
-      {breakEvenPoint && (
+      {breakEvenYears && (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -372,7 +373,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
             <CardContent className="space-y-6">
               <div className="space-y-2 text-center">
                 <div className="text-3xl font-bold text-amber-900">
-                  {breakEvenPoint.toFixed(1)} ans
+                  {breakEvenYears.toFixed(1)} ans
                 </div>
                 <div className="text-sm text-amber-700">
                   Point d&apos;équilibre entre achat et location
@@ -441,7 +442,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
           <CardContent className="space-y-4">
             <div
               className={`rounded-xl border-2 p-6 ${
-                isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                   ? 'border-blue-300 bg-blue-50'
                   : 'border-green-300 bg-green-50'
               }`}
@@ -449,12 +450,12 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
               <div className="flex items-start gap-4">
                 <div
                   className={`rounded-xl p-2 ${
-                    isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                    isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                       ? 'bg-blue-100'
                       : 'bg-green-100'
                   }`}
                 >
-                  {isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint ? (
+                  {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears ? (
                     <Home className="h-6 w-6 text-blue-600" />
                   ) : (
                     <ShoppingCart className="h-6 w-6 text-green-600" />
@@ -463,35 +464,35 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div className="flex-1">
                   <h3
                     className={`mb-2 text-lg font-bold ${
-                      isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                      isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                         ? 'text-blue-900'
                         : 'text-green-900'
                     }`}
                   >
-                    {isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                    {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                       ? 'Location recommandée'
                       : 'Achat recommandé'}
                   </h3>
                   <p
                     className={`mb-4 text-sm ${
-                      isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                      isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                         ? 'text-blue-800'
                         : 'text-green-800'
                     }`}
                   >
-                    {isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                    {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                       ? `Pour un projet de ${selectedTimeHorizon} ans, la location vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} tout en conservant votre flexibilité financière.`
                       : `Sur ${selectedTimeHorizon} ans, l'achat vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} et vous offre la propriété complète de l'équipement.`}
                   </p>
                   <div className="flex gap-3">
                     <Button
                       className={
-                        isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                        isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                           ? 'bg-blue-500 hover:bg-blue-600'
                           : 'bg-green-500 hover:bg-green-600'
                       }
                     >
-                      {isRentalBetter && breakEvenPoint && selectedTimeHorizon < breakEvenPoint
+                      {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
                         ? 'Opter pour la location'
                         : "Procéder à l'achat"}
                       <ArrowRight className="ml-2 h-4 w-4" />
@@ -513,8 +514,8 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </li>
                   <li>
                     •{' '}
-                    {breakEvenPoint
-                      ? `Point d'équilibre : ${breakEvenPoint.toFixed(1)} ans`
+                    {breakEvenYears
+                      ? `Point d'équilibre : ${breakEvenYears.toFixed(1)} ans`
                       : 'Pas de données de location disponibles'}
                   </li>
                 </ul>

--- a/src/lib/utils/project/calculations.test.ts
+++ b/src/lib/utils/project/calculations.test.ts
@@ -331,8 +331,7 @@ describe('calculateExtendedRentalCost', () => {
     // Post-3yr 1yr: ceilPrice(1.82 * 12 * 1) = ceilPrice(21.84) = 21.84
     // Total: ceilPrice(327.24 + 21.84) = 349.08
     const result = calculateExtendedRentalCost(9.09, 4)
-    expect(result).toBeGreaterThan(327.24)
-    expect(result).toBeLessThan(360)
+    expect(result).toBe(349.08)
   })
 
   it('calculates cost for 5 years (3yr full + 2yr at 20%)', () => {

--- a/src/lib/utils/project/calculations.test.ts
+++ b/src/lib/utils/project/calculations.test.ts
@@ -17,6 +17,7 @@ import {
   getProjectKitBreakdown,
   calculateEnvironmentalSavings,
   calculateBreakEvenPoint,
+  calculateExtendedRentalCost,
 } from './calculations'
 
 describe('calculateProjectPriceTotals', () => {
@@ -309,11 +310,42 @@ describe('calculateEnvironmentalSavings', () => {
   })
 })
 
+describe('calculateExtendedRentalCost', () => {
+  it('returns 0 for zero or negative inputs', () => {
+    expect(calculateExtendedRentalCost(0, 3)).toBe(0)
+    expect(calculateExtendedRentalCost(10, 0)).toBe(0)
+    expect(calculateExtendedRentalCost(-5, 3)).toBe(0)
+    expect(calculateExtendedRentalCost(10, -1)).toBe(0)
+  })
+
+  it('calculates cost for 3 years or less (full rate)', () => {
+    // 9.09 * 12 * 3 = 327.24
+    expect(calculateExtendedRentalCost(9.09, 3)).toBe(327.24)
+    // 9.09 * 12 * 1 = 109.08
+    expect(calculateExtendedRentalCost(9.09, 1)).toBe(109.08)
+  })
+
+  it('calculates cost for 4 years (3yr full + 1yr at 20%)', () => {
+    // Base 3yr: ceilPrice(9.09 * 12 * 3) = 327.24
+    // Post-3yr monthly: ceilPrice(9.09 * 0.20) = ceilPrice(1.818) = 1.82
+    // Post-3yr 1yr: ceilPrice(1.82 * 12 * 1) = ceilPrice(21.84) = 21.84
+    // Total: ceilPrice(327.24 + 21.84) = 349.08
+    const result = calculateExtendedRentalCost(9.09, 4)
+    expect(result).toBeGreaterThan(327.24)
+    expect(result).toBeLessThan(360)
+  })
+
+  it('calculates cost for 5 years (3yr full + 2yr at 20%)', () => {
+    const result = calculateExtendedRentalCost(9.09, 5)
+    const resultFor4 = calculateExtendedRentalCost(9.09, 4)
+    expect(result).toBeGreaterThan(resultFor4)
+  })
+})
+
 describe('calculateBreakEvenPoint', () => {
-  it('returns null when rental price is 0', () => {
+  it('returns null when all rental prices are 0', () => {
     const kitProduct = makeKitProduct(1, {
       prixVenteAchat: 1000,
-      // no location price = falls back to 0
     })
     const kit = makeKit([kitProduct])
     const project = makeProject([makeProjectKit(1, kit)])
@@ -321,34 +353,117 @@ describe('calculateBreakEvenPoint', () => {
     expect(calculateBreakEvenPoint(project)).toBeNull()
   })
 
-  it('calculates break-even as purchase / rental', () => {
+  it('returns null when purchase price is 0', () => {
     const kitProduct = makeKitProduct(1, {
-      prixVenteAchat: 1200,
+      prixVenteAchat: 0,
       prixVenteLocation1An: 100,
     })
     const kit = makeKit([kitProduct])
     const project = makeProject([makeProjectKit(1, kit)])
 
-    const breakEven = calculateBreakEvenPoint(project)
-    // 1200 / 100 = 12
-    expect(breakEven).toBe(12)
-  })
-
-  it('returns fractional break-even values', () => {
-    const kitProduct = makeKitProduct(1, {
-      prixVenteAchat: 1000,
-      prixVenteLocation1An: 300,
-    })
-    const kit = makeKit([kitProduct])
-    const project = makeProject([makeProjectKit(1, kit)])
-
-    const breakEven = calculateBreakEvenPoint(project)
-    expect(breakEven).toBeCloseTo(3.333, 2)
+    expect(calculateBreakEvenPoint(project)).toBeNull()
   })
 
   it('returns null for project without kits', () => {
     const project = makeProject()
-    // Both purchase and rental are 0, so rental = 0 -> null
     expect(calculateBreakEvenPoint(project)).toBeNull()
+  })
+
+  it('returns structured BreakEvenResult with phase 3ans+ when purchase >> rental', () => {
+    // Purchase = 8420.89, Location 3ans annual = 109.08 (9.09/month * 12)
+    // We use prixVente as annual prices in the schema
+    const kitProduct = makeKitProduct(1, {
+      prixVenteAchat: 8420.89,
+      prixVenteLocation1An: 109.08,
+      prixVenteLocation2Ans: 109.08,
+      prixVenteLocation3Ans: 109.08,
+    })
+    const kit = makeKit([kitProduct])
+    const project = makeProject([makeProjectKit(1, kit)])
+
+    const result = calculateBreakEvenPoint(project)
+    expect(result).not.toBeNull()
+    expect(result!.phase).toBe('3ans+')
+    expect(result!.breakEvenYears).toBeGreaterThan(3)
+    expect(result!.breakEvenMonths).toBe(result!.breakEvenYears * 12)
+  })
+
+  it('returns phase 0-1an when purchase < 1 year rental', () => {
+    // Purchase = 50, Location 1an annual = 1200 -> monthly = 100
+    // 50 - 100*12 = 50 - 1200 < 0 -> phase 0-1an
+    // months = 50 / 100 = 0.5 months
+    const kitProduct = makeKitProduct(1, {
+      prixVenteAchat: 50,
+      prixVenteLocation1An: 1200,
+      prixVenteLocation2Ans: 600,
+      prixVenteLocation3Ans: 400,
+    })
+    const kit = makeKit([kitProduct])
+    const project = makeProject([makeProjectKit(1, kit)])
+
+    const result = calculateBreakEvenPoint(project)
+    expect(result).not.toBeNull()
+    expect(result!.phase).toBe('0-1an')
+    expect(result!.breakEvenMonths).toBeLessThan(12)
+    expect(result!.breakEvenYears).toBeLessThan(1)
+  })
+
+  it('returns phase 1-2ans when break-even is between 1 and 2 years', () => {
+    // Purchase = 1500
+    // Location 1an annual = 1200 -> monthly = 100 -> 1500 - 1200 = 300 > 0
+    // Location 2ans annual = 900 -> monthly = 75 -> 1500 - 75*12*2 = 1500 - 1800 = -300 < 0
+    // months = 1500 / 75 = 20 months (between 12 and 24)
+    const kitProduct = makeKitProduct(1, {
+      prixVenteAchat: 1500,
+      prixVenteLocation1An: 1200,
+      prixVenteLocation2Ans: 900,
+      prixVenteLocation3Ans: 600,
+    })
+    const kit = makeKit([kitProduct])
+    const project = makeProject([makeProjectKit(1, kit)])
+
+    const result = calculateBreakEvenPoint(project)
+    expect(result).not.toBeNull()
+    expect(result!.phase).toBe('1-2ans')
+    expect(result!.breakEvenMonths).toBeGreaterThanOrEqual(12)
+    expect(result!.breakEvenMonths).toBeLessThan(24)
+  })
+
+  it('returns phase 2-3ans when break-even is between 2 and 3 years', () => {
+    // Purchase = 2000
+    // Location 1an annual = 1200 -> monthly = 100 -> 2000 - 1200 = 800 > 0
+    // Location 2ans annual = 900 -> monthly = 75 -> 2000 - 75*12*2 = 2000 - 1800 = 200 > 0
+    // Location 3ans annual = 720 -> monthly = 60 -> 2000 - 60*12*3 = 2000 - 2160 = -160 < 0
+    // Not reached by case 2.2.2 since remaining after 3yr < 0
+    // months = 2000 / 60 = 33.33 (between 24 and 36)
+    const kitProduct = makeKitProduct(1, {
+      prixVenteAchat: 2000,
+      prixVenteLocation1An: 1200,
+      prixVenteLocation2Ans: 900,
+      prixVenteLocation3Ans: 720,
+    })
+    const kit = makeKit([kitProduct])
+    const project = makeProject([makeProjectKit(1, kit)])
+
+    const result = calculateBreakEvenPoint(project)
+    expect(result).not.toBeNull()
+    expect(result!.phase).toBe('2-3ans')
+    expect(result!.breakEvenMonths).toBeGreaterThanOrEqual(24)
+    expect(result!.breakEvenMonths).toBeLessThan(36)
+  })
+
+  it('handles same price across all rental periods (fallback)', () => {
+    const kitProduct = makeKitProduct(1, {
+      prixVenteAchat: 5000,
+      prixVenteLocation1An: 120,
+    })
+    const kit = makeKit([kitProduct])
+    const project = makeProject([makeProjectKit(1, kit)])
+
+    const result = calculateBreakEvenPoint(project)
+    expect(result).not.toBeNull()
+    // With same rate, 3yr total = 10*12*3 = 360, purchase 5000 - 360 > 0 -> phase 3ans+
+    expect(result!.phase).toBe('3ans+')
+    expect(result!.breakEvenYears).toBeGreaterThan(3)
   })
 })

--- a/src/lib/utils/project/calculations.ts
+++ b/src/lib/utils/project/calculations.ts
@@ -1,6 +1,11 @@
 import type { Project, EnvironmentalImpact } from '@/lib/types/project'
 import type { PurchaseRentalMode, ProductPeriod } from '@/lib/schemas/product'
-import { getProductPricing, getProductEnvironmentalImpact } from '@/lib/utils/product-helpers'
+import {
+  getProductPricing,
+  getProductEnvironmentalImpact,
+  ceilPrice,
+  annualToMonthly,
+} from '@/lib/utils/product-helpers'
 
 export interface ProjectPriceTotals {
   achat: number
@@ -22,6 +27,14 @@ export interface KitBreakdownItem {
   totalCost: number
   totalMargin: number
   marginPercentage: number
+}
+
+export type BreakEvenPhase = '0-1an' | '1-2ans' | '2-3ans' | '3ans+'
+
+export interface BreakEvenResult {
+  breakEvenMonths: number
+  breakEvenYears: number
+  phase: BreakEvenPhase
 }
 
 const EMPTY_PRICE_TOTALS: ProjectPriceTotals = {
@@ -192,17 +205,115 @@ export function calculateEnvironmentalSavings(project: Project): EnvironmentalIm
 }
 
 /**
- * Calculate the break-even point in years between purchase and rental.
- * @param project - The project with its kits and products
- * @returns Number of years to break even, or null if rental price is zero
+ * Calculate the total rental cost for an extended duration using the tiered model:
+ * - First 3 years: full monthly rate (base 3 ans)
+ * - Beyond 3 years: 20% of the monthly rate (base 3 ans)
+ *
+ * @param monthlyBase3ans - Monthly rental price on a 3-year basis
+ * @param years - Total rental duration in years
+ * @returns Total rental cost for the given duration
  */
-export function calculateBreakEvenPoint(project: Project): number | null {
-  const purchaseCost = calculateProjectPurchaseCosts(project)
-  const rental1Year = calculateProjectRentalCosts(project, '1an')
+export function calculateExtendedRentalCost(monthlyBase3ans: number, years: number): number {
+  if (years <= 0 || monthlyBase3ans <= 0) return 0
 
-  if (rental1Year.totalPrice === 0) return null
+  if (years <= 3) {
+    return ceilPrice(monthlyBase3ans * 12 * years)
+  }
 
-  return purchaseCost.totalPrice / rental1Year.totalPrice
+  const baseThreeYearCost = ceilPrice(monthlyBase3ans * 12 * 3)
+  const postThreeYearMonthly = ceilPrice(monthlyBase3ans * 0.2)
+  const extraYears = years - 3
+  const postThreeYearCost = ceilPrice(postThreeYearMonthly * 12 * extraYears)
+
+  return ceilPrice(baseThreeYearCost + postThreeYearCost)
+}
+
+/**
+ * Calculate the break-even point between purchase and rental using a cascade algorithm.
+ *
+ * The algorithm checks progressively:
+ * 1. If break-even is beyond 3 years (using post-3yr reduced rate of 20%)
+ * 2. If break-even is between 0-1 year
+ * 3. If break-even is between 1-2 years
+ * 4. If break-even is between 2-3 years
+ *
+ * @param project - The project with its kits and products
+ * @returns Break-even result with months, years, and phase, or null if calculation is impossible
+ */
+export function calculateBreakEvenPoint(project: Project): BreakEvenResult | null {
+  const priceTotals = calculateProjectPriceTotals(project)
+  const purchasePrice = priceTotals.achat
+
+  if (purchasePrice <= 0) return null
+
+  const monthly1an = annualToMonthly(priceTotals.location1an)
+  const monthly2ans = annualToMonthly(priceTotals.location2ans)
+  const monthly3ans = annualToMonthly(priceTotals.location3ans)
+
+  if (monthly1an <= 0 && monthly2ans <= 0 && monthly3ans <= 0) return null
+
+  const effectiveMonthly3ans = monthly3ans > 0 ? monthly3ans : monthly1an
+  const effectiveMonthly2ans = monthly2ans > 0 ? monthly2ans : monthly1an
+
+  const threeYearRentalTotal = effectiveMonthly3ans * 12 * 3
+  const remainingAfter3Years = purchasePrice - threeYearRentalTotal
+
+  // Case 1: Break-even beyond 3 years
+  if (remainingAfter3Years > 0) {
+    const postMonthly = ceilPrice(effectiveMonthly3ans * 0.2)
+    if (postMonthly <= 0) return null
+
+    const extraYears = remainingAfter3Years / (postMonthly * 12)
+    const totalYears = extraYears + 3
+    const totalMonths = totalYears * 12
+
+    return {
+      breakEvenMonths: totalMonths,
+      breakEvenYears: totalYears,
+      phase: '3ans+',
+    }
+  }
+
+  // Case 2: Break-even within 0-3 years
+  const oneYearRentalTotal = monthly1an * 12
+
+  // Case 2.1: Break-even between 0 and 1 year
+  if (monthly1an > 0 && purchasePrice - oneYearRentalTotal < 0) {
+    const months = purchasePrice / monthly1an
+
+    return {
+      breakEvenMonths: months,
+      breakEvenYears: months / 12,
+      phase: '0-1an',
+    }
+  }
+
+  // Case 2.2: Break-even beyond 1 year
+  if (monthly1an > 0 && purchasePrice - oneYearRentalTotal >= 0) {
+    const twoYearRentalTotal = effectiveMonthly2ans * 12 * 2
+
+    // Case 2.2.1: Break-even between 1 and 2 years
+    if (purchasePrice - twoYearRentalTotal < 0) {
+      const months = purchasePrice / effectiveMonthly2ans
+
+      return {
+        breakEvenMonths: months,
+        breakEvenYears: months / 12,
+        phase: '1-2ans',
+      }
+    }
+
+    // Case 2.2.2: Break-even between 2 and 3 years
+    const months = purchasePrice / effectiveMonthly3ans
+
+    return {
+      breakEvenMonths: months,
+      breakEvenYears: months / 12,
+      phase: '2-3ans',
+    }
+  }
+
+  return null
 }
 
 function calculateCostsForMode(


### PR DESCRIPTION
## Summary

- Replace the naive break-even formula (`purchasePrice / rental1YearPrice`) with a cascade algorithm that checks progressively against 1an, 2ans, 3ans rental periods, then a post-3-year reduced rate (20% of the 3-year monthly price)
- Add `calculateExtendedRentalCost()` helper for tiered rental pricing beyond 3 years
- Return a structured `BreakEvenResult` object with phase detection instead of a raw number

## Related Issue

TRI-103, TRI-104

## Changes

### Core Calculation Logic (`src/lib/utils/project/calculations.ts`)
- Add `BreakEvenPhase` type (`0-1an`, `1-2ans`, `2-3ans`, `3ans+`) and `BreakEvenResult` interface
- Add `calculateExtendedRentalCost()` — tiered cost: full rate for first 3 years, 20% beyond
- Rewrite `calculateBreakEvenPoint()` with cascade algorithm from business spec:
  1. Check if break-even is beyond 3 years (post-3yr reduced rate)
  2. Check if break-even is between 0-1 year
  3. Check if break-even is between 1-2 years
  4. Check if break-even is between 2-3 years

### Consumer Update (`src/components/projects/purchase-rental-comparison.tsx`)
- Update all references from raw `breakEvenPoint` number to `breakEvenResult.breakEvenYears`
- No UI redesign (deferred to TRI-105/TRI-106)

### Tests (`src/lib/utils/project/calculations.test.ts`)
- Add tests for `calculateExtendedRentalCost` (zero inputs, 3yr, 4yr, 5yr)
- Replace old break-even tests with 8 new tests covering all 4 phases and edge cases

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [x] Unit tests pass (37 tests)
- [x] Manual testing done (`pnpm build` succeeds)

## Breaking Changes

`calculateBreakEvenPoint()` now returns `BreakEvenResult | null` instead of `number | null`. All consumers in this repo have been updated.
