### PR TITLE
feat(pricing): add getPostThreeYearMonthlyRate product helper

### DIFF
--- a/src/lib/utils/product-helpers.test.ts
+++ b/src/lib/utils/product-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   hasProductPricingData,
   hasProductEnvironmentalData,
   getDefaultProductMode,
+  getPostThreeYearMonthlyRate,
   formatPrice,
   formatEnvironmentalImpact,
 } from './product-helpers'
@@ -393,6 +394,46 @@ describe('getDefaultProductMode', () => {
       prixVente1An: null as unknown as number,
     })
     expect(getDefaultProductMode(product)).toBe('achat')
+  })
+})
+
+describe('getPostThreeYearMonthlyRate', () => {
+  it('returns 20% of the 3-year monthly rate with ceilPrice rounding', () => {
+    // prixVenteLocation3Ans = 109.08 (annual)
+    // monthly = ceilPrice(109.08 / 12) = ceilPrice(9.09) = 9.09
+    // post-3yr = ceilPrice(9.09 * 0.2) = ceilPrice(1.818) = 1.82
+    const product = makeProduct({
+      prixVenteLocation3Ans: 109.08,
+    })
+    expect(getPostThreeYearMonthlyRate(product)).toBe(1.82)
+  })
+
+  it('returns null when no rental pricing exists', () => {
+    const product = makeProduct()
+    // Legacy fields default to 0, so prixVente will be 0 via fallback
+    // annualToMonthly(0) = 0, monthly <= 0 -> returns null
+    expect(getPostThreeYearMonthlyRate(product)).toBeNull()
+  })
+
+  it('returns null when prixVente is null', () => {
+    const product = makeProduct({
+      prixVenteLocation1An: null as unknown as number,
+      prixVente1An: null as unknown as number,
+    })
+    expect(getPostThreeYearMonthlyRate(product)).toBeNull()
+  })
+
+  it('falls back to 1an pricing when 3ans is not set', () => {
+    // No 3ans pricing -> getProductPricing falls back to 1an
+    // prixVenteLocation1An = 120 (annual)
+    // monthly = ceilPrice(120 / 12) = 10
+    // post-3yr = ceilPrice(10 * 0.2) = 2
+    const product = makeProduct({
+      prixAchatLocation1An: 80,
+      prixUnitaireLocation1An: 100,
+      prixVenteLocation1An: 120,
+    })
+    expect(getPostThreeYearMonthlyRate(product)).toBe(2)
   })
 })
 

--- a/src/lib/utils/product-helpers.ts
+++ b/src/lib/utils/product-helpers.ts
@@ -210,6 +210,20 @@ export function formatPrice(price: number | null): string {
 }
 
 /**
+ * Returns the monthly rental rate for periods beyond 3 years (20% of the 3-year monthly rate).
+ *
+ * @param product - The product to extract the rate from
+ * @returns The post-3-year monthly rate ceiled to 2 decimals, or null if no rental pricing exists
+ */
+export function getPostThreeYearMonthlyRate(product: Product): number | null {
+  const pricing3ans = getProductPricing(product, 'location', '3ans')
+  if (pricing3ans.prixVente === null) return null
+  const monthly3ans = annualToMonthly(pricing3ans.prixVente)
+  if (monthly3ans <= 0) return null
+  return ceilPrice(monthly3ans * 0.2)
+}
+
+/**
  * Formats l'impact environnemental pour l'affichage
  */
 export function formatEnvironmentalImpact(


### PR DESCRIPTION
## Summary

- Add `getPostThreeYearMonthlyRate(product)` helper to extract the post-3-year monthly rental rate (20% of the 3-year base) directly from a Product object
- Complements the `calculateExtendedRentalCost` function added in TRI-103

## Related Issue

TRI-104

## Changes

- **`src/lib/utils/product-helpers.ts`**: Added `getPostThreeYearMonthlyRate(product)` — returns `ceilPrice(monthly3ans * 0.2)` or `null` if no rental pricing exists. Uses existing `getProductPricing` fallback chain and `annualToMonthly`.
- **`src/lib/utils/product-helpers.test.ts`**: Added 4 test cases covering correct 20% calculation with rounding, null returns for missing/zero pricing, and 1an fallback behavior.

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [x] Unit tests pass (92/92)
- [ ] Manual testing done
