### PR TITLE
feat(pricing): update PurchaseRentalComparison for tiered rental model

### DIFF
--- a/src/components/projects/purchase-rental-comparison.tsx
+++ b/src/components/projects/purchase-rental-comparison.tsx
@@ -1,29 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import {
-  Euro,
-  ShoppingCart,
-  Home,
-  TrendingUp,
-  Clock,
-  CheckCircle,
-  XCircle,
-  AlertCircle,
-  Calculator,
-  BarChart3,
-  ArrowRight,
-  Zap,
-  Shield,
-  Recycle,
-  DollarSign,
-  Calendar,
-  Lightbulb,
-} from 'lucide-react'
+import { ShoppingCart, Home, CheckCircle, XCircle, BarChart3 } from 'lucide-react'
 import type { Project } from '@/lib/types/project'
 import {
   formatPrice as formatPriceHelper,
@@ -35,37 +16,32 @@ import {
   calculateProjectRentalCosts,
   calculateBreakEvenPoint,
   calculateExtendedRentalCost,
+  calculatePostThreeYearMonthly,
 } from '@/lib/utils/project/calculations'
-
-const DEFAULT_MAX_HORIZON = 9
-const ABSOLUTE_MAX_HORIZON = 20
-
-const PHASE_LABELS: Record<string, string> = {
-  '0-1an': '0 - 1 an',
-  '1-2ans': '1 - 2 ans',
-  '2-3ans': '2 - 3 ans',
-  '3ans+': 'au-delà de 3 ans',
-}
-
-const PHASE_ORDER = ['0-1an', '1-2ans', '2-3ans', '3ans+'] as const
+import {
+  DEFAULT_MAX_HORIZON,
+  ABSOLUTE_MAX_HORIZON,
+  PURCHASE_ADVANTAGES,
+  PURCHASE_DISADVANTAGES,
+  RENTAL_ADVANTAGES,
+  RENTAL_DISADVANTAGES,
+} from './purchase-rental-comparison/constants'
+import { TimeHorizonSelector } from './purchase-rental-comparison/time-horizon-selector'
+import { RentalCostBreakdown } from './purchase-rental-comparison/rental-cost-breakdown'
+import { BreakEvenAnalysisCard } from './purchase-rental-comparison/break-even-analysis-card'
+import { RecommendationSection } from './purchase-rental-comparison/recommendation-section'
 
 interface PurchaseRentalComparisonProps {
   project: Project
 }
 
-function formatBreakEvenDuration(months: number): string {
-  const years = Math.floor(months / 12)
-  const remainingMonths = Math.round(months % 12)
-
-  if (remainingMonths === 0) {
-    return `${years} an${years > 1 ? 's' : ''}`
-  }
-  if (years === 0) {
-    return `${remainingMonths} mois`
-  }
-  return `${years} an${years > 1 ? 's' : ''} et ${remainingMonths} mois`
-}
-
+/**
+ * Side-by-side comparison of purchase vs rental options with tiered pricing model.
+ * Integrates break-even analysis, dynamic time horizon, and two-tier monthly cost display
+ * (full rate for first 3 years, 20% beyond).
+ * @param props - Project data for cost calculations
+ * @returns Interactive comparison view with time horizon selector and recommendation
+ */
 export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonProps) {
   const [selectedTimeHorizon, setSelectedTimeHorizon] = useState(3)
 
@@ -78,76 +54,30 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
   const breakEvenPhase = breakEvenResult?.phase ?? null
 
   const monthly3ans = annualToMonthly(rental3Years.totalPrice)
-  const postThreeYearMonthly = ceilPrice(monthly3ans * 0.2)
+  const postThreeYearMonthly = calculatePostThreeYearMonthly(monthly3ans)
 
-  // Dynamic horizon: adapt slider to break-even range, cap at 20
   const dynamicMax = breakEvenYears
     ? Math.min(Math.max(Math.ceil(breakEvenYears) + 2, DEFAULT_MAX_HORIZON), ABSOLUTE_MAX_HORIZON)
     : DEFAULT_MAX_HORIZON
-  const timeHorizons = Array.from({ length: dynamicMax }, (_, i) => i + 1)
+  const timeHorizons = useMemo(
+    () => Array.from({ length: dynamicMax }, (_, i) => i + 1),
+    [dynamicMax],
+  )
   const isBreakEvenBeyondMax = breakEvenYears !== null && breakEvenYears > ABSOLUTE_MAX_HORIZON
 
-  const getProjectedCosts = (years: number) => {
+  const projectedCosts = useMemo(() => {
     const purchaseCostTotal = purchaseData.totalPrice
-    const rentalCostTotal = calculateExtendedRentalCost(monthly3ans, years)
-
+    const rentalCostTotal = calculateExtendedRentalCost(monthly3ans, selectedTimeHorizon)
     return {
       purchase: purchaseCostTotal,
       rental: rentalCostTotal,
       savings: purchaseCostTotal - rentalCostTotal,
     }
-  }
+  }, [purchaseData.totalPrice, monthly3ans, selectedTimeHorizon])
 
-  const projectedCosts = getProjectedCosts(selectedTimeHorizon)
   const isRentalBetter = projectedCosts.savings > 0
-
-  const purchaseAdvantages = [
-    { icon: DollarSign, text: "Propriété complète de l'équipement" },
-    { icon: TrendingUp, text: "Pas de coûts récurrents après l'achat" },
-    { icon: Shield, text: "Contrôle total sur l'équipement" },
-    { icon: Calendar, text: 'Utilisation illimitée dans le temps' },
-    { icon: Zap, text: 'Potentiel de revente en fin de vie' },
-  ]
-
-  const purchaseDisadvantages = [
-    { icon: AlertCircle, text: 'Investissement initial important' },
-    { icon: XCircle, text: 'Responsabilité maintenance et réparations' },
-    { icon: Clock, text: 'Obsolescence technologique à votre charge' },
-    { icon: Euro, text: 'Immobilisation de capital importante' },
-  ]
-
-  const rentalAdvantages = [
-    { icon: Euro, text: 'Coût initial faible, étalement des paiements' },
-    { icon: Shield, text: 'Maintenance incluse dans le service' },
-    { icon: Zap, text: 'Flexibilité et mise à niveau possible' },
-    { icon: Recycle, text: 'Impact environnemental réduit' },
-    { icon: Calculator, text: 'Coûts prévisibles et budgétables' },
-  ]
-
-  const rentalDisadvantages = [
-    { icon: TrendingUp, text: 'Coût total plus élevé sur le long terme' },
-    { icon: XCircle, text: "Pas de propriété de l'équipement" },
-    { icon: Calendar, text: 'Contraintes contractuelles de durée' },
-    { icon: AlertCircle, text: 'Dépendance au fournisseur' },
-  ]
-
   const recommendsRental =
     isRentalBetter && breakEvenYears !== null && selectedTimeHorizon < breakEvenYears
-
-  const getRecommendationText = (): string => {
-    if (recommendsRental) {
-      const base = `Pour un projet de ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, la location vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} tout en conservant votre flexibilité financière.`
-      if (breakEvenPhase === '3ans+' && selectedTimeHorizon > 3) {
-        return `${base} Après 3 ans, le tarif de location passe à ${formatPriceHelper(postThreeYearMonthly)}/mois (20% du tarif initial).`
-      }
-      return base
-    }
-    const base = `Sur ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, l'achat vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} et vous offre la propriété complète de l'équipement.`
-    if (breakEvenPhase === '3ans+' && selectedTimeHorizon > 3) {
-      return `${base} Même avec le tarif réduit de ${formatPriceHelper(postThreeYearMonthly)}/mois après 3 ans, l'achat reste plus avantageux.`
-    }
-    return base
-  }
 
   return (
     <div className="space-y-8">
@@ -165,48 +95,13 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
         </p>
       </div>
 
-      {/* Time Horizon Selector */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, delay: 0.1 }}
-      >
-        <Card className="border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 shadow-lg">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-3">
-              <div className="rounded-xl bg-gradient-to-br from-purple-100 to-pink-100 p-2">
-                <Clock className="h-5 w-5 text-purple-600" />
-              </div>
-              Horizon temporel d&apos;analyse
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="flex flex-wrap justify-center gap-3">
-              {timeHorizons.map((years) => (
-                <Button
-                  key={years}
-                  variant={selectedTimeHorizon === years ? 'default' : 'outline'}
-                  onClick={() => setSelectedTimeHorizon(years)}
-                  className={
-                    selectedTimeHorizon === years ? 'bg-purple-500 hover:bg-purple-600' : ''
-                  }
-                >
-                  {years} an{years > 1 ? 's' : ''}
-                </Button>
-              ))}
-            </div>
-            {isBreakEvenBeyondMax && (
-              <div className="flex items-center justify-center gap-2 text-sm text-amber-700">
-                <AlertCircle className="h-4 w-4" />
-                <span>
-                  Le point d&apos;équilibre dépasse {ABSOLUTE_MAX_HORIZON} ans
-                  {breakEvenYears !== null && ` (${formatBreakEvenDuration(breakEvenYears * 12)})`}
-                </span>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </motion.div>
+      <TimeHorizonSelector
+        timeHorizons={timeHorizons}
+        selectedTimeHorizon={selectedTimeHorizon}
+        onSelect={setSelectedTimeHorizon}
+        isBreakEvenBeyondMax={isBreakEvenBeyondMax}
+        breakEvenYears={breakEvenYears}
+      />
 
       {/* Main Comparison Cards */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
@@ -262,35 +157,20 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                 </div>
 
-                <div>
-                  <h4 className="mb-3 flex items-center gap-2 font-semibold text-green-900">
-                    <CheckCircle className="h-4 w-4" />
-                    Avantages
-                  </h4>
-                  <div className="space-y-2">
-                    {purchaseAdvantages.map((advantage, index) => (
-                      <div key={index} className="flex items-center gap-3 text-sm text-green-800">
-                        <advantage.icon className="h-4 w-4 flex-shrink-0 text-green-600" />
-                        <span>{advantage.text}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <AdvantageList
+                  title="Avantages"
+                  items={PURCHASE_ADVANTAGES}
+                  colorScheme="green"
+                  icon={<CheckCircle className="h-4 w-4" />}
+                />
 
-                <div>
-                  <h4 className="mb-3 flex items-center gap-2 font-semibold text-green-900">
-                    <XCircle className="h-4 w-4" />
-                    Inconvénients
-                  </h4>
-                  <div className="space-y-2">
-                    {purchaseDisadvantages.map((disadvantage, index) => (
-                      <div key={index} className="flex items-center gap-3 text-sm text-green-700">
-                        <disadvantage.icon className="h-4 w-4 flex-shrink-0 text-green-500" />
-                        <span>{disadvantage.text}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <AdvantageList
+                  title="Inconvénients"
+                  items={PURCHASE_DISADVANTAGES}
+                  colorScheme="green"
+                  variant="muted"
+                  icon={<XCircle className="h-4 w-4" />}
+                />
               </div>
             </CardContent>
           </Card>
@@ -337,67 +217,12 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
 
               <div className="space-y-4">
                 <div className="space-y-3 rounded-xl border border-white/50 bg-white/60 p-4">
-                  {selectedTimeHorizon <= 3 ? (
-                    <>
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-blue-800">Coût mensuel</span>
-                        <div className="flex items-center gap-1.5">
-                          <span className="font-bold text-blue-900">
-                            {formatPriceHelper(monthly3ans)}
-                          </span>
-                          <Badge
-                            variant="outline"
-                            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
-                          >
-                            /mois
-                          </Badge>
-                        </div>
-                      </div>
-                      <div className="flex items-center justify-between text-xs text-blue-600">
-                        <span>Coût annuel</span>
-                        <span>{formatPriceHelper(rental3Years.totalPrice)} /an</span>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-blue-800">
-                          Tarif 3 premières années
-                        </span>
-                        <div className="flex items-center gap-1.5">
-                          <span className="font-bold text-blue-900">
-                            {formatPriceHelper(monthly3ans)}
-                          </span>
-                          <Badge
-                            variant="outline"
-                            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
-                          >
-                            /mois
-                          </Badge>
-                        </div>
-                      </div>
-                      <div className="h-px bg-blue-200/50"></div>
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-blue-800">
-                          Tarif au-delà de 3 ans
-                        </span>
-                        <div className="flex items-center gap-1.5">
-                          <span className="font-bold text-blue-900">
-                            {formatPriceHelper(postThreeYearMonthly)}
-                          </span>
-                          <Badge
-                            variant="outline"
-                            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
-                          >
-                            /mois
-                          </Badge>
-                        </div>
-                      </div>
-                      <div className="text-center text-xs text-blue-500">
-                        20% du tarif initial après 3 ans
-                      </div>
-                    </>
-                  )}
+                  <RentalCostBreakdown
+                    selectedTimeHorizon={selectedTimeHorizon}
+                    monthly3ans={monthly3ans}
+                    postThreeYearMonthly={postThreeYearMonthly}
+                    annualRentalPrice={rental3Years.totalPrice}
+                  />
                   <div className="h-px bg-blue-200/50"></div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-blue-800">
@@ -410,273 +235,104 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                 </div>
 
-                <div>
-                  <h4 className="mb-3 flex items-center gap-2 font-semibold text-blue-900">
-                    <CheckCircle className="h-4 w-4" />
-                    Avantages
-                  </h4>
-                  <div className="space-y-2">
-                    {rentalAdvantages.map((advantage, index) => (
-                      <div key={index} className="flex items-center gap-3 text-sm text-blue-800">
-                        <advantage.icon className="h-4 w-4 flex-shrink-0 text-blue-600" />
-                        <span>{advantage.text}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <AdvantageList
+                  title="Avantages"
+                  items={RENTAL_ADVANTAGES}
+                  colorScheme="blue"
+                  icon={<CheckCircle className="h-4 w-4" />}
+                />
 
-                <div>
-                  <h4 className="mb-3 flex items-center gap-2 font-semibold text-blue-900">
-                    <XCircle className="h-4 w-4" />
-                    Inconvénients
-                  </h4>
-                  <div className="space-y-2">
-                    {rentalDisadvantages.map((disadvantage, index) => (
-                      <div key={index} className="flex items-center gap-3 text-sm text-blue-700">
-                        <disadvantage.icon className="h-4 w-4 flex-shrink-0 text-blue-500" />
-                        <span>{disadvantage.text}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <AdvantageList
+                  title="Inconvénients"
+                  items={RENTAL_DISADVANTAGES}
+                  colorScheme="blue"
+                  variant="muted"
+                  icon={<XCircle className="h-4 w-4" />}
+                />
               </div>
             </CardContent>
           </Card>
         </motion.div>
       </div>
 
-      {/* Break-Even Analysis */}
       {breakEvenResult && breakEvenYears && breakEvenMonths && breakEvenPhase && (
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.4 }}
-        >
-          <Card className="border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 shadow-lg">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3">
-                <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-2">
-                  <TrendingUp className="h-5 w-5 text-amber-600" />
-                </div>
-                Analyse de rentabilité
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-2 text-center">
-                <div className="text-3xl font-bold text-amber-900">
-                  {formatBreakEvenDuration(breakEvenMonths)}
-                </div>
-                <div className="text-sm text-amber-700">
-                  Point d&apos;équilibre entre achat et location
-                </div>
-                <div className="text-xs text-amber-600">
-                  Phase : {PHASE_LABELS[breakEvenPhase] ?? breakEvenPhase}
-                </div>
-              </div>
-
-              {/* Visual Timeline */}
-              <div className="space-y-2">
-                <div className="flex h-8 overflow-hidden rounded-lg">
-                  {PHASE_ORDER.map((phase) => {
-                    const isActive = phase === breakEvenPhase
-                    const baseClasses =
-                      'flex items-center justify-center text-[10px] font-medium transition-all'
-                    const activeClasses = isActive
-                      ? 'bg-amber-400 text-amber-900 ring-2 ring-amber-500 ring-offset-1'
-                      : 'bg-amber-100 text-amber-600'
-                    const widthClass = phase === '3ans+' ? 'flex-[2]' : 'flex-1'
-
-                    return (
-                      <div key={phase} className={`${baseClasses} ${activeClasses} ${widthClass}`}>
-                        {PHASE_LABELS[phase]}
-                      </div>
-                    )
-                  })}
-                </div>
-                {/* Break-even marker position */}
-                <div className="relative h-2">
-                  <div
-                    className="absolute top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-amber-600 shadow-sm"
-                    style={{
-                      left: `${Math.min((breakEvenYears / Math.max(dynamicMax, breakEvenYears)) * 100, 100)}%`,
-                    }}
-                  />
-                  <div className="h-px w-full bg-amber-200" />
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
-                  <div className="mb-1 text-2xl font-bold text-amber-900">
-                    {formatPriceHelper(Math.abs(projectedCosts.savings))}
-                  </div>
-                  <div className="text-sm text-amber-700">
-                    {projectedCosts.savings >= 0 ? 'Économies' : 'Surcoût'} sur{' '}
-                    {selectedTimeHorizon} an{selectedTimeHorizon > 1 ? 's' : ''}
-                  </div>
-                </div>
-                <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
-                  <div className="mb-1 text-2xl font-bold text-amber-900">
-                    {projectedCosts.purchase > 0
-                      ? (
-                          (Math.abs(projectedCosts.savings) / projectedCosts.purchase) *
-                          100
-                        ).toFixed(1)
-                      : '0.0'}
-                    %
-                  </div>
-                  <div className="text-sm text-amber-700">
-                    {projectedCosts.savings >= 0 ? 'Économie' : 'Surcoût'} relatif
-                  </div>
-                </div>
-                <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
-                  {breakEvenPhase === '3ans+' ? (
-                    <>
-                      <div className="mb-1 flex items-center justify-center gap-1.5">
-                        <span className="text-lg font-bold text-amber-900">
-                          {formatPriceHelper(monthly3ans)}
-                        </span>
-                        <Badge
-                          variant="outline"
-                          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
-                        >
-                          /mois
-                        </Badge>
-                      </div>
-                      <div className="text-xs text-amber-700">3 premières années</div>
-                      <div className="my-1 h-px bg-amber-200/50" />
-                      <div className="flex items-center justify-center gap-1.5">
-                        <span className="text-lg font-bold text-amber-900">
-                          {formatPriceHelper(postThreeYearMonthly)}
-                        </span>
-                        <Badge
-                          variant="outline"
-                          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
-                        >
-                          /mois
-                        </Badge>
-                      </div>
-                      <div className="text-xs text-amber-600">au-delà de 3 ans (20%)</div>
-                    </>
-                  ) : (
-                    <>
-                      <div className="mb-1 flex items-center justify-center gap-1.5">
-                        <span className="text-2xl font-bold text-amber-900">
-                          {formatPriceHelper(monthly3ans)}
-                        </span>
-                        <Badge
-                          variant="outline"
-                          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
-                        >
-                          /mois
-                        </Badge>
-                      </div>
-                      <div className="text-sm text-amber-700">Coût mensuel location</div>
-                      <div className="mt-0.5 text-xs text-amber-500">
-                        {formatPriceHelper(rental3Years.totalPrice)} /an
-                      </div>
-                    </>
-                  )}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
+        <BreakEvenAnalysisCard
+          breakEvenYears={breakEvenYears}
+          breakEvenMonths={breakEvenMonths}
+          breakEvenPhase={breakEvenPhase}
+          projectedCosts={projectedCosts}
+          selectedTimeHorizon={selectedTimeHorizon}
+          monthly3ans={monthly3ans}
+          postThreeYearMonthly={postThreeYearMonthly}
+          annualRentalPrice={rental3Years.totalPrice}
+          dynamicMax={dynamicMax}
+        />
       )}
 
-      {/* Smart Recommendation */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, delay: 0.5 }}
-      >
-        <Card className="border-indigo-200 bg-gradient-to-br from-indigo-50 to-violet-50 shadow-lg">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-3">
-              <div className="rounded-xl bg-gradient-to-br from-indigo-100 to-violet-100 p-2">
-                <Lightbulb className="h-5 w-5 text-indigo-600" />
-              </div>
-              Recommandation intelligente
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div
-              className={`rounded-xl border-2 p-6 ${
-                recommendsRental ? 'border-blue-300 bg-blue-50' : 'border-green-300 bg-green-50'
-              }`}
-            >
-              <div className="flex items-start gap-4">
-                <div
-                  className={`rounded-xl p-2 ${recommendsRental ? 'bg-blue-100' : 'bg-green-100'}`}
-                >
-                  {recommendsRental ? (
-                    <Home className="h-6 w-6 text-blue-600" />
-                  ) : (
-                    <ShoppingCart className="h-6 w-6 text-green-600" />
-                  )}
-                </div>
-                <div className="flex-1">
-                  <h3
-                    className={`mb-2 text-lg font-bold ${
-                      recommendsRental ? 'text-blue-900' : 'text-green-900'
-                    }`}
-                  >
-                    {recommendsRental ? 'Location recommandée' : 'Achat recommandé'}
-                  </h3>
-                  <p
-                    className={`mb-4 text-sm ${
-                      recommendsRental ? 'text-blue-800' : 'text-green-800'
-                    }`}
-                  >
-                    {getRecommendationText()}
-                  </p>
-                  <div className="flex gap-3">
-                    <Button
-                      className={
-                        recommendsRental
-                          ? 'bg-blue-500 hover:bg-blue-600'
-                          : 'bg-green-500 hover:bg-green-600'
-                      }
-                    >
-                      {recommendsRental ? 'Opter pour la location' : "Procéder à l'achat"}
-                      <ArrowRight className="ml-2 h-4 w-4" />
-                    </Button>
-                    <Button variant="outline">Obtenir un devis détaillé</Button>
-                  </div>
-                </div>
-              </div>
-            </div>
+      <RecommendationSection
+        recommendsRental={recommendsRental}
+        selectedTimeHorizon={selectedTimeHorizon}
+        projectedCosts={projectedCosts}
+        breakEvenPhase={breakEvenPhase}
+        postThreeYearMonthly={postThreeYearMonthly}
+        breakEvenYears={breakEvenYears}
+        breakEvenMonths={breakEvenMonths}
+        projectKitCount={project.projectKits?.length || 0}
+      />
+    </div>
+  )
+}
 
-            <div className="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
-              <div className="rounded-xl border border-white/50 bg-white/60 p-4">
-                <h4 className="mb-2 font-semibold text-indigo-900">Contexte de projet</h4>
-                <ul className="space-y-1 text-indigo-800">
-                  <li>• {project.projectKits?.length || 0} types de kits configurés</li>
-                  <li>
-                    • Durée d&apos;analyse : {selectedTimeHorizon} an
-                    {selectedTimeHorizon > 1 ? 's' : ''}
-                  </li>
-                  <li>
-                    •{' '}
-                    {breakEvenYears
-                      ? `Point d'équilibre : ${formatBreakEvenDuration(breakEvenMonths ?? breakEvenYears * 12)}`
-                      : 'Pas de données de location disponibles'}
-                  </li>
-                </ul>
-              </div>
-              <div className="rounded-xl border border-white/50 bg-white/60 p-4">
-                <h4 className="mb-2 font-semibold text-indigo-900">Facteurs à considérer</h4>
-                <ul className="space-y-1 text-indigo-800">
-                  <li>• Capacité d&apos;investissement initial</li>
-                  <li>• Durée prévue d&apos;utilisation</li>
-                  <li>• Besoins de flexibilité</li>
-                  <li>• Évolution technologique prévue</li>
-                </ul>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </motion.div>
+const COLOR_CLASSES = {
+  green: {
+    heading: 'text-green-900',
+    text: 'text-green-800',
+    textMuted: 'text-green-700',
+    icon: 'text-green-600',
+    iconMuted: 'text-green-500',
+  },
+  blue: {
+    heading: 'text-blue-900',
+    text: 'text-blue-800',
+    textMuted: 'text-blue-700',
+    icon: 'text-blue-600',
+    iconMuted: 'text-blue-500',
+  },
+} as const
+
+interface AdvantageListProps {
+  title: string
+  items: ReadonlyArray<{ icon: React.ComponentType<{ className?: string }>; text: string }>
+  colorScheme: 'green' | 'blue'
+  variant?: 'default' | 'muted'
+  icon: React.ReactNode
+}
+
+function AdvantageList({
+  title,
+  items,
+  colorScheme,
+  variant = 'default',
+  icon,
+}: AdvantageListProps) {
+  const colors = COLOR_CLASSES[colorScheme]
+  const textColor = variant === 'muted' ? colors.textMuted : colors.text
+  const iconColor = variant === 'muted' ? colors.iconMuted : colors.icon
+
+  return (
+    <div>
+      <h4 className={`mb-3 flex items-center gap-2 font-semibold ${colors.heading}`}>
+        {icon}
+        {title}
+      </h4>
+      <div className="space-y-2">
+        {items.map((item, index) => (
+          <div key={index} className={`flex items-center gap-3 text-sm ${textColor}`}>
+            <item.icon className={`h-4 w-4 flex-shrink-0 ${iconColor}`} />
+            <span>{item.text}</span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/projects/purchase-rental-comparison.tsx
+++ b/src/components/projects/purchase-rental-comparison.tsx
@@ -30,6 +30,7 @@ import { TimeHorizonSelector } from './purchase-rental-comparison/time-horizon-s
 import { RentalCostBreakdown } from './purchase-rental-comparison/rental-cost-breakdown'
 import { BreakEvenAnalysisCard } from './purchase-rental-comparison/break-even-analysis-card'
 import { RecommendationSection } from './purchase-rental-comparison/recommendation-section'
+import { AdvantageList } from './purchase-rental-comparison/advantage-list'
 
 interface PurchaseRentalComparisonProps {
   project: Project
@@ -42,7 +43,7 @@ interface PurchaseRentalComparisonProps {
  * @param props - Project data for cost calculations
  * @returns Interactive comparison view with time horizon selector and recommendation
  */
-export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonProps) {
+export function PurchaseRentalComparison({ project }: Readonly<PurchaseRentalComparisonProps>) {
   const [selectedTimeHorizon, setSelectedTimeHorizon] = useState(3)
 
   const purchaseData = calculateProjectPurchaseCosts(project)
@@ -279,60 +280,6 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
         breakEvenMonths={breakEvenMonths}
         projectKitCount={project.projectKits?.length || 0}
       />
-    </div>
-  )
-}
-
-const COLOR_CLASSES = {
-  green: {
-    heading: 'text-green-900',
-    text: 'text-green-800',
-    textMuted: 'text-green-700',
-    icon: 'text-green-600',
-    iconMuted: 'text-green-500',
-  },
-  blue: {
-    heading: 'text-blue-900',
-    text: 'text-blue-800',
-    textMuted: 'text-blue-700',
-    icon: 'text-blue-600',
-    iconMuted: 'text-blue-500',
-  },
-} as const
-
-interface AdvantageListProps {
-  title: string
-  items: ReadonlyArray<{ icon: React.ComponentType<{ className?: string }>; text: string }>
-  colorScheme: 'green' | 'blue'
-  variant?: 'default' | 'muted'
-  icon: React.ReactNode
-}
-
-function AdvantageList({
-  title,
-  items,
-  colorScheme,
-  variant = 'default',
-  icon,
-}: AdvantageListProps) {
-  const colors = COLOR_CLASSES[colorScheme]
-  const textColor = variant === 'muted' ? colors.textMuted : colors.text
-  const iconColor = variant === 'muted' ? colors.iconMuted : colors.icon
-
-  return (
-    <div>
-      <h4 className={`mb-3 flex items-center gap-2 font-semibold ${colors.heading}`}>
-        {icon}
-        {title}
-      </h4>
-      <div className="space-y-2">
-        {items.map((item, index) => (
-          <div key={index} className={`flex items-center gap-3 text-sm ${textColor}`}>
-            <item.icon className={`h-4 w-4 flex-shrink-0 ${iconColor}`} />
-            <span>{item.text}</span>
-          </div>
-        ))}
-      </div>
     </div>
   )
 }

--- a/src/components/projects/purchase-rental-comparison.tsx
+++ b/src/components/projects/purchase-rental-comparison.tsx
@@ -44,7 +44,7 @@ const PHASE_LABELS: Record<string, string> = {
   '0-1an': '0 - 1 an',
   '1-2ans': '1 - 2 ans',
   '2-3ans': '2 - 3 ans',
-  '3ans+': 'au-dela de 3 ans',
+  '3ans+': 'au-delà de 3 ans',
 }
 
 const PHASE_ORDER = ['0-1an', '1-2ans', '2-3ans', '3ans+'] as const
@@ -102,33 +102,33 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
   const isRentalBetter = projectedCosts.savings > 0
 
   const purchaseAdvantages = [
-    { icon: DollarSign, text: "Propriete complete de l'equipement" },
-    { icon: TrendingUp, text: "Pas de couts recurrents apres l'achat" },
-    { icon: Shield, text: "Controle total sur l'equipement" },
-    { icon: Calendar, text: 'Utilisation illimitee dans le temps' },
+    { icon: DollarSign, text: "Propriété complète de l'équipement" },
+    { icon: TrendingUp, text: "Pas de coûts récurrents après l'achat" },
+    { icon: Shield, text: "Contrôle total sur l'équipement" },
+    { icon: Calendar, text: 'Utilisation illimitée dans le temps' },
     { icon: Zap, text: 'Potentiel de revente en fin de vie' },
   ]
 
   const purchaseDisadvantages = [
     { icon: AlertCircle, text: 'Investissement initial important' },
-    { icon: XCircle, text: 'Responsabilite maintenance et reparations' },
-    { icon: Clock, text: 'Obsolescence technologique a votre charge' },
+    { icon: XCircle, text: 'Responsabilité maintenance et réparations' },
+    { icon: Clock, text: 'Obsolescence technologique à votre charge' },
     { icon: Euro, text: 'Immobilisation de capital importante' },
   ]
 
   const rentalAdvantages = [
-    { icon: Euro, text: 'Cout initial faible, etalement des paiements' },
+    { icon: Euro, text: 'Coût initial faible, étalement des paiements' },
     { icon: Shield, text: 'Maintenance incluse dans le service' },
-    { icon: Zap, text: 'Flexibilite et mise a niveau possible' },
-    { icon: Recycle, text: 'Impact environnemental reduit' },
-    { icon: Calculator, text: 'Couts previsibles et budgetables' },
+    { icon: Zap, text: 'Flexibilité et mise à niveau possible' },
+    { icon: Recycle, text: 'Impact environnemental réduit' },
+    { icon: Calculator, text: 'Coûts prévisibles et budgétables' },
   ]
 
   const rentalDisadvantages = [
-    { icon: TrendingUp, text: 'Cout total plus eleve sur le long terme' },
-    { icon: XCircle, text: "Pas de propriete de l'equipement" },
-    { icon: Calendar, text: 'Contraintes contractuelles de duree' },
-    { icon: AlertCircle, text: 'Dependance au fournisseur' },
+    { icon: TrendingUp, text: 'Coût total plus élevé sur le long terme' },
+    { icon: XCircle, text: "Pas de propriété de l'équipement" },
+    { icon: Calendar, text: 'Contraintes contractuelles de durée' },
+    { icon: AlertCircle, text: 'Dépendance au fournisseur' },
   ]
 
   const recommendsRental =
@@ -136,15 +136,15 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
 
   const getRecommendationText = (): string => {
     if (recommendsRental) {
-      const base = `Pour un projet de ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, la location vous permet d'economiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} tout en conservant votre flexibilite financiere.`
+      const base = `Pour un projet de ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, la location vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} tout en conservant votre flexibilité financière.`
       if (breakEvenPhase === '3ans+' && selectedTimeHorizon > 3) {
-        return `${base} Apres 3 ans, le tarif de location passe a ${formatPriceHelper(postThreeYearMonthly)}/mois (20% du tarif initial).`
+        return `${base} Après 3 ans, le tarif de location passe à ${formatPriceHelper(postThreeYearMonthly)}/mois (20% du tarif initial).`
       }
       return base
     }
-    const base = `Sur ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, l'achat vous permet d'economiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} et vous offre la propriete complete de l'equipement.`
+    const base = `Sur ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, l'achat vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} et vous offre la propriété complète de l'équipement.`
     if (breakEvenPhase === '3ans+' && selectedTimeHorizon > 3) {
-      return `${base} Meme avec le tarif reduit de ${formatPriceHelper(postThreeYearMonthly)}/mois apres 3 ans, l'achat reste plus avantageux.`
+      return `${base} Même avec le tarif réduit de ${formatPriceHelper(postThreeYearMonthly)}/mois après 3 ans, l'achat reste plus avantageux.`
     }
     return base
   }
@@ -161,7 +161,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
         </div>
         <p className="mx-auto max-w-2xl text-gray-600">
           Analysez les deux options pour faire le meilleur choix selon vos besoins et votre
-          situation financiere
+          situation financière
         </p>
       </div>
 
@@ -199,7 +199,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
               <div className="flex items-center justify-center gap-2 text-sm text-amber-700">
                 <AlertCircle className="h-4 w-4" />
                 <span>
-                  Le point d&apos;equilibre depasse {ABSOLUTE_MAX_HORIZON} ans
+                  Le point d&apos;équilibre dépasse {ABSOLUTE_MAX_HORIZON} ans
                   {breakEvenYears !== null && ` (${formatBreakEvenDuration(breakEvenYears * 12)})`}
                 </span>
               </div>
@@ -226,7 +226,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   <CardTitle className="text-xl text-green-900">Achat</CardTitle>
                 </div>
                 {!isRentalBetter && breakEvenYears && selectedTimeHorizon > breakEvenYears && (
-                  <Badge className="bg-green-500 text-white">Recommande</Badge>
+                  <Badge className="bg-green-500 text-white">Recommandé</Badge>
                 )}
               </div>
             </CardHeader>
@@ -236,7 +236,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   {formatPriceHelper(projectedCosts.purchase)}
                 </div>
                 <div className="text-sm font-medium text-green-700">
-                  Cout total sur {selectedTimeHorizon} an
+                  Coût total sur {selectedTimeHorizon} an
                   {selectedTimeHorizon > 1 ? 's' : ''}
                 </div>
               </div>
@@ -245,7 +245,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div className="rounded-xl border border-white/50 bg-white/60 p-4">
                   <div className="mb-2 flex items-center justify-between">
                     <span className="text-sm font-medium text-green-800">
-                      Cout d&apos;acquisition (unique)
+                      Coût d&apos;acquisition (unique)
                     </span>
                     <span className="font-bold text-green-900">
                       {formatPriceHelper(purchaseData.totalPrice)}
@@ -253,7 +253,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-green-800">
-                      Cout sur {selectedTimeHorizon} an
+                      Coût sur {selectedTimeHorizon} an
                       {selectedTimeHorizon > 1 ? 's' : ''}
                     </span>
                     <span className="font-bold text-green-900">
@@ -280,7 +280,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div>
                   <h4 className="mb-3 flex items-center gap-2 font-semibold text-green-900">
                     <XCircle className="h-4 w-4" />
-                    Inconvenients
+                    Inconvénients
                   </h4>
                   <div className="space-y-2">
                     {purchaseDisadvantages.map((disadvantage, index) => (
@@ -311,7 +311,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                   <CardTitle className="text-xl text-blue-900">Location</CardTitle>
                 </div>
-                {recommendsRental && <Badge className="bg-blue-500 text-white">Recommande</Badge>}
+                {recommendsRental && <Badge className="bg-blue-500 text-white">Recommandé</Badge>}
               </div>
             </CardHeader>
             <CardContent className="space-y-6">
@@ -340,7 +340,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   {selectedTimeHorizon <= 3 ? (
                     <>
                       <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-blue-800">Cout mensuel</span>
+                        <span className="text-sm font-medium text-blue-800">Coût mensuel</span>
                         <div className="flex items-center gap-1.5">
                           <span className="font-bold text-blue-900">
                             {formatPriceHelper(monthly3ans)}
@@ -354,7 +354,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                         </div>
                       </div>
                       <div className="flex items-center justify-between text-xs text-blue-600">
-                        <span>Cout annuel</span>
+                        <span>Coût annuel</span>
                         <span>{formatPriceHelper(rental3Years.totalPrice)} /an</span>
                       </div>
                     </>
@@ -362,7 +362,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                     <>
                       <div className="flex items-center justify-between">
                         <span className="text-sm font-medium text-blue-800">
-                          Tarif 3 premieres annees
+                          Tarif 3 premières années
                         </span>
                         <div className="flex items-center gap-1.5">
                           <span className="font-bold text-blue-900">
@@ -379,7 +379,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                       <div className="h-px bg-blue-200/50"></div>
                       <div className="flex items-center justify-between">
                         <span className="text-sm font-medium text-blue-800">
-                          Tarif au-dela de 3 ans
+                          Tarif au-delà de 3 ans
                         </span>
                         <div className="flex items-center gap-1.5">
                           <span className="font-bold text-blue-900">
@@ -394,14 +394,14 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                         </div>
                       </div>
                       <div className="text-center text-xs text-blue-500">
-                        20% du tarif initial apres 3 ans
+                        20% du tarif initial après 3 ans
                       </div>
                     </>
                   )}
                   <div className="h-px bg-blue-200/50"></div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-blue-800">
-                      Cout sur {selectedTimeHorizon} an
+                      Coût sur {selectedTimeHorizon} an
                       {selectedTimeHorizon > 1 ? 's' : ''}
                     </span>
                     <span className="font-bold text-blue-900">
@@ -428,7 +428,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div>
                   <h4 className="mb-3 flex items-center gap-2 font-semibold text-blue-900">
                     <XCircle className="h-4 w-4" />
-                    Inconvenients
+                    Inconvénients
                   </h4>
                   <div className="space-y-2">
                     {rentalDisadvantages.map((disadvantage, index) => (
@@ -458,7 +458,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-2">
                   <TrendingUp className="h-5 w-5 text-amber-600" />
                 </div>
-                Analyse de rentabilite
+                Analyse de rentabilité
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
@@ -467,7 +467,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   {formatBreakEvenDuration(breakEvenMonths)}
                 </div>
                 <div className="text-sm text-amber-700">
-                  Point d&apos;equilibre entre achat et location
+                  Point d&apos;équilibre entre achat et location
                 </div>
                 <div className="text-xs text-amber-600">
                   Phase : {PHASE_LABELS[breakEvenPhase] ?? breakEvenPhase}
@@ -511,7 +511,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                     {formatPriceHelper(Math.abs(projectedCosts.savings))}
                   </div>
                   <div className="text-sm text-amber-700">
-                    {projectedCosts.savings >= 0 ? 'Economies' : 'Surcout'} sur{' '}
+                    {projectedCosts.savings >= 0 ? 'Économies' : 'Surcoût'} sur{' '}
                     {selectedTimeHorizon} an{selectedTimeHorizon > 1 ? 's' : ''}
                   </div>
                 </div>
@@ -526,7 +526,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                     %
                   </div>
                   <div className="text-sm text-amber-700">
-                    {projectedCosts.savings >= 0 ? 'Economie' : 'Surcout'} relatif
+                    {projectedCosts.savings >= 0 ? 'Économie' : 'Surcoût'} relatif
                   </div>
                 </div>
                 <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
@@ -543,7 +543,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                           /mois
                         </Badge>
                       </div>
-                      <div className="text-xs text-amber-700">3 premieres annees</div>
+                      <div className="text-xs text-amber-700">3 premières années</div>
                       <div className="my-1 h-px bg-amber-200/50" />
                       <div className="flex items-center justify-center gap-1.5">
                         <span className="text-lg font-bold text-amber-900">
@@ -556,7 +556,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                           /mois
                         </Badge>
                       </div>
-                      <div className="text-xs text-amber-600">au-dela de 3 ans (20%)</div>
+                      <div className="text-xs text-amber-600">au-delà de 3 ans (20%)</div>
                     </>
                   ) : (
                     <>
@@ -571,7 +571,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                           /mois
                         </Badge>
                       </div>
-                      <div className="text-sm text-amber-700">Cout mensuel location</div>
+                      <div className="text-sm text-amber-700">Coût mensuel location</div>
                       <div className="mt-0.5 text-xs text-amber-500">
                         {formatPriceHelper(rental3Years.totalPrice)} /an
                       </div>
@@ -621,7 +621,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                       recommendsRental ? 'text-blue-900' : 'text-green-900'
                     }`}
                   >
-                    {recommendsRental ? 'Location recommandee' : 'Achat recommande'}
+                    {recommendsRental ? 'Location recommandée' : 'Achat recommandé'}
                   </h3>
                   <p
                     className={`mb-4 text-sm ${
@@ -638,10 +638,10 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                           : 'bg-green-500 hover:bg-green-600'
                       }
                     >
-                      {recommendsRental ? 'Opter pour la location' : "Proceder a l'achat"}
+                      {recommendsRental ? 'Opter pour la location' : "Procéder à l'achat"}
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
-                    <Button variant="outline">Obtenir un devis detaille</Button>
+                    <Button variant="outline">Obtenir un devis détaillé</Button>
                   </div>
                 </div>
               </div>
@@ -651,26 +651,26 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
               <div className="rounded-xl border border-white/50 bg-white/60 p-4">
                 <h4 className="mb-2 font-semibold text-indigo-900">Contexte de projet</h4>
                 <ul className="space-y-1 text-indigo-800">
-                  <li>• {project.projectKits?.length || 0} types de kits configures</li>
+                  <li>• {project.projectKits?.length || 0} types de kits configurés</li>
                   <li>
-                    • Duree d&apos;analyse : {selectedTimeHorizon} an
+                    • Durée d&apos;analyse : {selectedTimeHorizon} an
                     {selectedTimeHorizon > 1 ? 's' : ''}
                   </li>
                   <li>
                     •{' '}
                     {breakEvenYears
-                      ? `Point d'equilibre : ${formatBreakEvenDuration(breakEvenMonths ?? breakEvenYears * 12)}`
-                      : 'Pas de donnees de location disponibles'}
+                      ? `Point d'équilibre : ${formatBreakEvenDuration(breakEvenMonths ?? breakEvenYears * 12)}`
+                      : 'Pas de données de location disponibles'}
                   </li>
                 </ul>
               </div>
               <div className="rounded-xl border border-white/50 bg-white/60 p-4">
-                <h4 className="mb-2 font-semibold text-indigo-900">Facteurs a considerer</h4>
+                <h4 className="mb-2 font-semibold text-indigo-900">Facteurs à considérer</h4>
                 <ul className="space-y-1 text-indigo-800">
-                  <li>• Capacite d&apos;investissement initial</li>
-                  <li>• Duree prevue d&apos;utilisation</li>
-                  <li>• Besoins de flexibilite</li>
-                  <li>• Evolution technologique prevue</li>
+                  <li>• Capacité d&apos;investissement initial</li>
+                  <li>• Durée prévue d&apos;utilisation</li>
+                  <li>• Besoins de flexibilité</li>
+                  <li>• Évolution technologique prévue</li>
                 </ul>
               </div>
             </div>

--- a/src/components/projects/purchase-rental-comparison.tsx
+++ b/src/components/projects/purchase-rental-comparison.tsx
@@ -25,46 +25,71 @@ import {
   Lightbulb,
 } from 'lucide-react'
 import type { Project } from '@/lib/types/project'
-import { formatPrice as formatPriceHelper, annualToMonthly } from '@/lib/utils/product-helpers'
+import {
+  formatPrice as formatPriceHelper,
+  annualToMonthly,
+  ceilPrice,
+} from '@/lib/utils/product-helpers'
 import {
   calculateProjectPurchaseCosts,
   calculateProjectRentalCosts,
   calculateBreakEvenPoint,
+  calculateExtendedRentalCost,
 } from '@/lib/utils/project/calculations'
+
+const DEFAULT_MAX_HORIZON = 9
+const ABSOLUTE_MAX_HORIZON = 20
+
+const PHASE_LABELS: Record<string, string> = {
+  '0-1an': '0 - 1 an',
+  '1-2ans': '1 - 2 ans',
+  '2-3ans': '2 - 3 ans',
+  '3ans+': 'au-dela de 3 ans',
+}
+
+const PHASE_ORDER = ['0-1an', '1-2ans', '2-3ans', '3ans+'] as const
 
 interface PurchaseRentalComparisonProps {
   project: Project
 }
 
-/**
- * Side-by-side comparison of purchase vs rental options with break-even analysis.
- * @param props - Project data for cost calculations
- * @returns Interactive comparison view with time horizon selector and recommendation
- */
+function formatBreakEvenDuration(months: number): string {
+  const years = Math.floor(months / 12)
+  const remainingMonths = Math.round(months % 12)
+
+  if (remainingMonths === 0) {
+    return `${years} an${years > 1 ? 's' : ''}`
+  }
+  if (years === 0) {
+    return `${remainingMonths} mois`
+  }
+  return `${years} an${years > 1 ? 's' : ''} et ${remainingMonths} mois`
+}
+
 export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonProps) {
   const [selectedTimeHorizon, setSelectedTimeHorizon] = useState(3)
 
   const purchaseData = calculateProjectPurchaseCosts(project)
-  const rental1Year = calculateProjectRentalCosts(project, '1an')
-  const rental2Years = calculateProjectRentalCosts(project, '2ans')
   const rental3Years = calculateProjectRentalCosts(project, '3ans')
 
   const breakEvenResult = calculateBreakEvenPoint(project)
   const breakEvenYears = breakEvenResult?.breakEvenYears ?? null
+  const breakEvenMonths = breakEvenResult?.breakEvenMonths ?? null
+  const breakEvenPhase = breakEvenResult?.phase ?? null
 
-  const getRentalDataForHorizon = (years: number) => {
-    if (years <= 1) return rental1Year
-    if (years <= 2) return rental2Years
-    return rental3Years
-  }
+  const monthly3ans = annualToMonthly(rental3Years.totalPrice)
+  const postThreeYearMonthly = ceilPrice(monthly3ans * 0.2)
 
-  const currentRentalData = getRentalDataForHorizon(selectedTimeHorizon)
+  // Dynamic horizon: adapt slider to break-even range, cap at 20
+  const dynamicMax = breakEvenYears
+    ? Math.min(Math.max(Math.ceil(breakEvenYears) + 2, DEFAULT_MAX_HORIZON), ABSOLUTE_MAX_HORIZON)
+    : DEFAULT_MAX_HORIZON
+  const timeHorizons = Array.from({ length: dynamicMax }, (_, i) => i + 1)
+  const isBreakEvenBeyondMax = breakEvenYears !== null && breakEvenYears > ABSOLUTE_MAX_HORIZON
 
   const getProjectedCosts = (years: number) => {
     const purchaseCostTotal = purchaseData.totalPrice
-    const rentalData = getRentalDataForHorizon(years)
-    const rentalCostPerYear = rentalData.totalPrice
-    const rentalCostTotal = rentalCostPerYear * years
+    const rentalCostTotal = calculateExtendedRentalCost(monthly3ans, years)
 
     return {
       purchase: purchaseCostTotal,
@@ -76,39 +101,53 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
   const projectedCosts = getProjectedCosts(selectedTimeHorizon)
   const isRentalBetter = projectedCosts.savings > 0
 
-  // Purchase advantages
   const purchaseAdvantages = [
-    { icon: DollarSign, text: "Propriété complète de l'équipement" },
-    { icon: TrendingUp, text: "Pas de coûts récurrents après l'achat" },
-    { icon: Shield, text: "Contrôle total sur l'équipement" },
-    { icon: Calendar, text: 'Utilisation illimitée dans le temps' },
+    { icon: DollarSign, text: "Propriete complete de l'equipement" },
+    { icon: TrendingUp, text: "Pas de couts recurrents apres l'achat" },
+    { icon: Shield, text: "Controle total sur l'equipement" },
+    { icon: Calendar, text: 'Utilisation illimitee dans le temps' },
     { icon: Zap, text: 'Potentiel de revente en fin de vie' },
   ]
 
   const purchaseDisadvantages = [
     { icon: AlertCircle, text: 'Investissement initial important' },
-    { icon: XCircle, text: 'Responsabilité maintenance et réparations' },
-    { icon: Clock, text: 'Obsolescence technologique à votre charge' },
+    { icon: XCircle, text: 'Responsabilite maintenance et reparations' },
+    { icon: Clock, text: 'Obsolescence technologique a votre charge' },
     { icon: Euro, text: 'Immobilisation de capital importante' },
   ]
 
-  // Rental advantages
   const rentalAdvantages = [
-    { icon: Euro, text: 'Coût initial faible, étalement des paiements' },
+    { icon: Euro, text: 'Cout initial faible, etalement des paiements' },
     { icon: Shield, text: 'Maintenance incluse dans le service' },
-    { icon: Zap, text: 'Flexibilité et mise à niveau possible' },
-    { icon: Recycle, text: 'Impact environnemental réduit' },
-    { icon: Calculator, text: 'Coûts prévisibles et budgétables' },
+    { icon: Zap, text: 'Flexibilite et mise a niveau possible' },
+    { icon: Recycle, text: 'Impact environnemental reduit' },
+    { icon: Calculator, text: 'Couts previsibles et budgetables' },
   ]
 
   const rentalDisadvantages = [
-    { icon: TrendingUp, text: 'Coût total plus élevé sur le long terme' },
-    { icon: XCircle, text: "Pas de propriété de l'équipement" },
-    { icon: Calendar, text: 'Contraintes contractuelles de durée' },
-    { icon: AlertCircle, text: 'Dépendance au fournisseur' },
+    { icon: TrendingUp, text: 'Cout total plus eleve sur le long terme' },
+    { icon: XCircle, text: "Pas de propriete de l'equipement" },
+    { icon: Calendar, text: 'Contraintes contractuelles de duree' },
+    { icon: AlertCircle, text: 'Dependance au fournisseur' },
   ]
 
-  const timeHorizons = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  const recommendsRental =
+    isRentalBetter && breakEvenYears !== null && selectedTimeHorizon < breakEvenYears
+
+  const getRecommendationText = (): string => {
+    if (recommendsRental) {
+      const base = `Pour un projet de ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, la location vous permet d'economiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} tout en conservant votre flexibilite financiere.`
+      if (breakEvenPhase === '3ans+' && selectedTimeHorizon > 3) {
+        return `${base} Apres 3 ans, le tarif de location passe a ${formatPriceHelper(postThreeYearMonthly)}/mois (20% du tarif initial).`
+      }
+      return base
+    }
+    const base = `Sur ${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}, l'achat vous permet d'economiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} et vous offre la propriete complete de l'equipement.`
+    if (breakEvenPhase === '3ans+' && selectedTimeHorizon > 3) {
+      return `${base} Meme avec le tarif reduit de ${formatPriceHelper(postThreeYearMonthly)}/mois apres 3 ans, l'achat reste plus avantageux.`
+    }
+    return base
+  }
 
   return (
     <div className="space-y-8">
@@ -122,11 +161,11 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
         </div>
         <p className="mx-auto max-w-2xl text-gray-600">
           Analysez les deux options pour faire le meilleur choix selon vos besoins et votre
-          situation financière
+          situation financiere
         </p>
       </div>
 
-      {/* Time Horizon Selector - Moved to top */}
+      {/* Time Horizon Selector */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -141,7 +180,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
               Horizon temporel d&apos;analyse
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-3">
             <div className="flex flex-wrap justify-center gap-3">
               {timeHorizons.map((years) => (
                 <Button
@@ -156,6 +195,15 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 </Button>
               ))}
             </div>
+            {isBreakEvenBeyondMax && (
+              <div className="flex items-center justify-center gap-2 text-sm text-amber-700">
+                <AlertCircle className="h-4 w-4" />
+                <span>
+                  Le point d&apos;equilibre depasse {ABSOLUTE_MAX_HORIZON} ans
+                  {breakEvenYears !== null && ` (${formatBreakEvenDuration(breakEvenYears * 12)})`}
+                </span>
+              </div>
+            )}
           </CardContent>
         </Card>
       </motion.div>
@@ -178,7 +226,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   <CardTitle className="text-xl text-green-900">Achat</CardTitle>
                 </div>
                 {!isRentalBetter && breakEvenYears && selectedTimeHorizon > breakEvenYears && (
-                  <Badge className="bg-green-500 text-white">Recommandé</Badge>
+                  <Badge className="bg-green-500 text-white">Recommande</Badge>
                 )}
               </div>
             </CardHeader>
@@ -188,7 +236,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   {formatPriceHelper(projectedCosts.purchase)}
                 </div>
                 <div className="text-sm font-medium text-green-700">
-                  Coût total sur {selectedTimeHorizon} an
+                  Cout total sur {selectedTimeHorizon} an
                   {selectedTimeHorizon > 1 ? 's' : ''}
                 </div>
               </div>
@@ -197,7 +245,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div className="rounded-xl border border-white/50 bg-white/60 p-4">
                   <div className="mb-2 flex items-center justify-between">
                     <span className="text-sm font-medium text-green-800">
-                      Coût d&apos;acquisition (unique)
+                      Cout d&apos;acquisition (unique)
                     </span>
                     <span className="font-bold text-green-900">
                       {formatPriceHelper(purchaseData.totalPrice)}
@@ -205,7 +253,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-green-800">
-                      Coût sur {selectedTimeHorizon} an
+                      Cout sur {selectedTimeHorizon} an
                       {selectedTimeHorizon > 1 ? 's' : ''}
                     </span>
                     <span className="font-bold text-green-900">
@@ -232,7 +280,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div>
                   <h4 className="mb-3 flex items-center gap-2 font-semibold text-green-900">
                     <XCircle className="h-4 w-4" />
-                    Inconvénients
+                    Inconvenients
                   </h4>
                   <div className="space-y-2">
                     {purchaseDisadvantages.map((disadvantage, index) => (
@@ -263,22 +311,22 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                   </div>
                   <CardTitle className="text-xl text-blue-900">Location</CardTitle>
                 </div>
-                {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears && (
-                  <Badge className="bg-blue-500 text-white">Recommandé</Badge>
-                )}
+                {recommendsRental && <Badge className="bg-blue-500 text-white">Recommande</Badge>}
               </div>
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="text-center">
                 <div className="mb-1 flex items-center justify-center gap-2">
                   <span className="text-4xl font-bold text-blue-900">
-                    {formatPriceHelper(projectedCosts.rental / (selectedTimeHorizon * 12))}
+                    {formatPriceHelper(
+                      ceilPrice(projectedCosts.rental / (selectedTimeHorizon * 12)),
+                    )}
                   </span>
                   <Badge
                     variant="outline"
                     className="border-blue-400 bg-blue-50 px-2 py-0.5 text-xs text-blue-600"
                   >
-                    /mois
+                    /mois moy.
                   </Badge>
                 </div>
                 <div className="mb-2 text-sm text-blue-500">
@@ -289,28 +337,71 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
 
               <div className="space-y-4">
                 <div className="space-y-3 rounded-xl border border-white/50 bg-white/60 p-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-blue-800">Coût mensuel</span>
-                    <div className="flex items-center gap-1.5">
-                      <span className="font-bold text-blue-900">
-                        {formatPriceHelper(annualToMonthly(currentRentalData.totalPrice))}
-                      </span>
-                      <Badge
-                        variant="outline"
-                        className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
-                      >
-                        /mois
-                      </Badge>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between text-xs text-blue-600">
-                    <span>Coût annuel</span>
-                    <span>{formatPriceHelper(currentRentalData.totalPrice)} /an</span>
-                  </div>
+                  {selectedTimeHorizon <= 3 ? (
+                    <>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-blue-800">Cout mensuel</span>
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-bold text-blue-900">
+                            {formatPriceHelper(monthly3ans)}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
+                          >
+                            /mois
+                          </Badge>
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between text-xs text-blue-600">
+                        <span>Cout annuel</span>
+                        <span>{formatPriceHelper(rental3Years.totalPrice)} /an</span>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-blue-800">
+                          Tarif 3 premieres annees
+                        </span>
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-bold text-blue-900">
+                            {formatPriceHelper(monthly3ans)}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
+                          >
+                            /mois
+                          </Badge>
+                        </div>
+                      </div>
+                      <div className="h-px bg-blue-200/50"></div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-blue-800">
+                          Tarif au-dela de 3 ans
+                        </span>
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-bold text-blue-900">
+                            {formatPriceHelper(postThreeYearMonthly)}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
+                          >
+                            /mois
+                          </Badge>
+                        </div>
+                      </div>
+                      <div className="text-center text-xs text-blue-500">
+                        20% du tarif initial apres 3 ans
+                      </div>
+                    </>
+                  )}
                   <div className="h-px bg-blue-200/50"></div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium text-blue-800">
-                      Coût sur {selectedTimeHorizon} an
+                      Cout sur {selectedTimeHorizon} an
                       {selectedTimeHorizon > 1 ? 's' : ''}
                     </span>
                     <span className="font-bold text-blue-900">
@@ -337,7 +428,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div>
                   <h4 className="mb-3 flex items-center gap-2 font-semibold text-blue-900">
                     <XCircle className="h-4 w-4" />
-                    Inconvénients
+                    Inconvenients
                   </h4>
                   <div className="space-y-2">
                     {rentalDisadvantages.map((disadvantage, index) => (
@@ -355,7 +446,7 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
       </div>
 
       {/* Break-Even Analysis */}
-      {breakEvenYears && (
+      {breakEvenResult && breakEvenYears && breakEvenMonths && breakEvenPhase && (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -367,16 +458,50 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-2">
                   <TrendingUp className="h-5 w-5 text-amber-600" />
                 </div>
-                Analyse de rentabilité
+                Analyse de rentabilite
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="space-y-2 text-center">
                 <div className="text-3xl font-bold text-amber-900">
-                  {breakEvenYears.toFixed(1)} ans
+                  {formatBreakEvenDuration(breakEvenMonths)}
                 </div>
                 <div className="text-sm text-amber-700">
-                  Point d&apos;équilibre entre achat et location
+                  Point d&apos;equilibre entre achat et location
+                </div>
+                <div className="text-xs text-amber-600">
+                  Phase : {PHASE_LABELS[breakEvenPhase] ?? breakEvenPhase}
+                </div>
+              </div>
+
+              {/* Visual Timeline */}
+              <div className="space-y-2">
+                <div className="flex h-8 overflow-hidden rounded-lg">
+                  {PHASE_ORDER.map((phase) => {
+                    const isActive = phase === breakEvenPhase
+                    const baseClasses =
+                      'flex items-center justify-center text-[10px] font-medium transition-all'
+                    const activeClasses = isActive
+                      ? 'bg-amber-400 text-amber-900 ring-2 ring-amber-500 ring-offset-1'
+                      : 'bg-amber-100 text-amber-600'
+                    const widthClass = phase === '3ans+' ? 'flex-[2]' : 'flex-1'
+
+                    return (
+                      <div key={phase} className={`${baseClasses} ${activeClasses} ${widthClass}`}>
+                        {PHASE_LABELS[phase]}
+                      </div>
+                    )
+                  })}
+                </div>
+                {/* Break-even marker position */}
+                <div className="relative h-2">
+                  <div
+                    className="absolute top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-amber-600 shadow-sm"
+                    style={{
+                      left: `${Math.min((breakEvenYears / Math.max(dynamicMax, breakEvenYears)) * 100, 100)}%`,
+                    }}
+                  />
+                  <div className="h-px w-full bg-amber-200" />
                 </div>
               </div>
 
@@ -386,37 +511,72 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                     {formatPriceHelper(Math.abs(projectedCosts.savings))}
                   </div>
                   <div className="text-sm text-amber-700">
-                    {projectedCosts.savings >= 0 ? 'Économies' : 'Surcoût'} sur{' '}
-                    {selectedTimeHorizon} ans
+                    {projectedCosts.savings >= 0 ? 'Economies' : 'Surcout'} sur{' '}
+                    {selectedTimeHorizon} an{selectedTimeHorizon > 1 ? 's' : ''}
                   </div>
                 </div>
                 <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
                   <div className="mb-1 text-2xl font-bold text-amber-900">
-                    {((Math.abs(projectedCosts.savings) / projectedCosts.purchase) * 100).toFixed(
-                      1,
-                    )}
+                    {projectedCosts.purchase > 0
+                      ? (
+                          (Math.abs(projectedCosts.savings) / projectedCosts.purchase) *
+                          100
+                        ).toFixed(1)
+                      : '0.0'}
                     %
                   </div>
                   <div className="text-sm text-amber-700">
-                    {projectedCosts.savings >= 0 ? 'Économie' : 'Surcoût'} relatif
+                    {projectedCosts.savings >= 0 ? 'Economie' : 'Surcout'} relatif
                   </div>
                 </div>
                 <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
-                  <div className="mb-1 flex items-center justify-center gap-1.5">
-                    <span className="text-2xl font-bold text-amber-900">
-                      {formatPriceHelper(annualToMonthly(currentRentalData.totalPrice))}
-                    </span>
-                    <Badge
-                      variant="outline"
-                      className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
-                    >
-                      /mois
-                    </Badge>
-                  </div>
-                  <div className="text-sm text-amber-700">Coût mensuel location</div>
-                  <div className="mt-0.5 text-xs text-amber-500">
-                    {formatPriceHelper(currentRentalData.totalPrice)} /an
-                  </div>
+                  {breakEvenPhase === '3ans+' ? (
+                    <>
+                      <div className="mb-1 flex items-center justify-center gap-1.5">
+                        <span className="text-lg font-bold text-amber-900">
+                          {formatPriceHelper(monthly3ans)}
+                        </span>
+                        <Badge
+                          variant="outline"
+                          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
+                        >
+                          /mois
+                        </Badge>
+                      </div>
+                      <div className="text-xs text-amber-700">3 premieres annees</div>
+                      <div className="my-1 h-px bg-amber-200/50" />
+                      <div className="flex items-center justify-center gap-1.5">
+                        <span className="text-lg font-bold text-amber-900">
+                          {formatPriceHelper(postThreeYearMonthly)}
+                        </span>
+                        <Badge
+                          variant="outline"
+                          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
+                        >
+                          /mois
+                        </Badge>
+                      </div>
+                      <div className="text-xs text-amber-600">au-dela de 3 ans (20%)</div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="mb-1 flex items-center justify-center gap-1.5">
+                        <span className="text-2xl font-bold text-amber-900">
+                          {formatPriceHelper(monthly3ans)}
+                        </span>
+                        <Badge
+                          variant="outline"
+                          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
+                        >
+                          /mois
+                        </Badge>
+                      </div>
+                      <div className="text-sm text-amber-700">Cout mensuel location</div>
+                      <div className="mt-0.5 text-xs text-amber-500">
+                        {formatPriceHelper(rental3Years.totalPrice)} /an
+                      </div>
+                    </>
+                  )}
                 </div>
               </div>
             </CardContent>
@@ -442,20 +602,14 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
           <CardContent className="space-y-4">
             <div
               className={`rounded-xl border-2 p-6 ${
-                isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                  ? 'border-blue-300 bg-blue-50'
-                  : 'border-green-300 bg-green-50'
+                recommendsRental ? 'border-blue-300 bg-blue-50' : 'border-green-300 bg-green-50'
               }`}
             >
               <div className="flex items-start gap-4">
                 <div
-                  className={`rounded-xl p-2 ${
-                    isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                      ? 'bg-blue-100'
-                      : 'bg-green-100'
-                  }`}
+                  className={`rounded-xl p-2 ${recommendsRental ? 'bg-blue-100' : 'bg-green-100'}`}
                 >
-                  {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears ? (
+                  {recommendsRental ? (
                     <Home className="h-6 w-6 text-blue-600" />
                   ) : (
                     <ShoppingCart className="h-6 w-6 text-green-600" />
@@ -464,40 +618,30 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
                 <div className="flex-1">
                   <h3
                     className={`mb-2 text-lg font-bold ${
-                      isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                        ? 'text-blue-900'
-                        : 'text-green-900'
+                      recommendsRental ? 'text-blue-900' : 'text-green-900'
                     }`}
                   >
-                    {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                      ? 'Location recommandée'
-                      : 'Achat recommandé'}
+                    {recommendsRental ? 'Location recommandee' : 'Achat recommande'}
                   </h3>
                   <p
                     className={`mb-4 text-sm ${
-                      isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                        ? 'text-blue-800'
-                        : 'text-green-800'
+                      recommendsRental ? 'text-blue-800' : 'text-green-800'
                     }`}
                   >
-                    {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                      ? `Pour un projet de ${selectedTimeHorizon} ans, la location vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} tout en conservant votre flexibilité financière.`
-                      : `Sur ${selectedTimeHorizon} ans, l'achat vous permet d'économiser ${formatPriceHelper(Math.abs(projectedCosts.savings))} et vous offre la propriété complète de l'équipement.`}
+                    {getRecommendationText()}
                   </p>
                   <div className="flex gap-3">
                     <Button
                       className={
-                        isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
+                        recommendsRental
                           ? 'bg-blue-500 hover:bg-blue-600'
                           : 'bg-green-500 hover:bg-green-600'
                       }
                     >
-                      {isRentalBetter && breakEvenYears && selectedTimeHorizon < breakEvenYears
-                        ? 'Opter pour la location'
-                        : "Procéder à l'achat"}
+                      {recommendsRental ? 'Opter pour la location' : "Proceder a l'achat"}
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
-                    <Button variant="outline">Obtenir un devis détaillé</Button>
+                    <Button variant="outline">Obtenir un devis detaille</Button>
                   </div>
                 </div>
               </div>
@@ -507,26 +651,26 @@ export function PurchaseRentalComparison({ project }: PurchaseRentalComparisonPr
               <div className="rounded-xl border border-white/50 bg-white/60 p-4">
                 <h4 className="mb-2 font-semibold text-indigo-900">Contexte de projet</h4>
                 <ul className="space-y-1 text-indigo-800">
-                  <li>• {project.projectKits?.length || 0} types de kits configurés</li>
+                  <li>• {project.projectKits?.length || 0} types de kits configures</li>
                   <li>
-                    • Durée d&apos;analyse : {selectedTimeHorizon} an
+                    • Duree d&apos;analyse : {selectedTimeHorizon} an
                     {selectedTimeHorizon > 1 ? 's' : ''}
                   </li>
                   <li>
                     •{' '}
                     {breakEvenYears
-                      ? `Point d'équilibre : ${breakEvenYears.toFixed(1)} ans`
-                      : 'Pas de données de location disponibles'}
+                      ? `Point d'equilibre : ${formatBreakEvenDuration(breakEvenMonths ?? breakEvenYears * 12)}`
+                      : 'Pas de donnees de location disponibles'}
                   </li>
                 </ul>
               </div>
               <div className="rounded-xl border border-white/50 bg-white/60 p-4">
-                <h4 className="mb-2 font-semibold text-indigo-900">Facteurs à considérer</h4>
+                <h4 className="mb-2 font-semibold text-indigo-900">Facteurs a considerer</h4>
                 <ul className="space-y-1 text-indigo-800">
-                  <li>• Capacité d&apos;investissement initial</li>
-                  <li>• Durée prévue d&apos;utilisation</li>
-                  <li>• Besoins de flexibilité</li>
-                  <li>• Évolution technologique prévue</li>
+                  <li>• Capacite d&apos;investissement initial</li>
+                  <li>• Duree prevue d&apos;utilisation</li>
+                  <li>• Besoins de flexibilite</li>
+                  <li>• Evolution technologique prevue</li>
                 </ul>
               </div>
             </div>

--- a/src/components/projects/purchase-rental-comparison/advantage-list.tsx
+++ b/src/components/projects/purchase-rental-comparison/advantage-list.tsx
@@ -1,0 +1,60 @@
+import type { LucideIcon } from 'lucide-react'
+
+const COLOR_CLASSES = {
+  green: {
+    heading: 'text-green-900',
+    text: 'text-green-800',
+    textMuted: 'text-green-700',
+    icon: 'text-green-600',
+    iconMuted: 'text-green-500',
+  },
+  blue: {
+    heading: 'text-blue-900',
+    text: 'text-blue-800',
+    textMuted: 'text-blue-700',
+    icon: 'text-blue-600',
+    iconMuted: 'text-blue-500',
+  },
+} as const
+
+interface AdvantageListProps {
+  title: string
+  items: ReadonlyArray<{ readonly icon: LucideIcon; readonly text: string }>
+  colorScheme: 'green' | 'blue'
+  variant?: 'default' | 'muted'
+  icon: React.ReactNode
+}
+
+/**
+ * Renders a list of advantages or disadvantages with color-coded icons and text.
+ * @param props - Title, items, color scheme, and optional variant for muted styling
+ * @returns Styled list of advantage/disadvantage items
+ */
+export function AdvantageList({
+  title,
+  items,
+  colorScheme,
+  variant = 'default',
+  icon,
+}: Readonly<AdvantageListProps>) {
+  const colors = COLOR_CLASSES[colorScheme]
+  const textColor = variant === 'muted' ? colors.textMuted : colors.text
+  const iconColor = variant === 'muted' ? colors.iconMuted : colors.icon
+
+  return (
+    <div>
+      <h4 className={`mb-3 flex items-center gap-2 font-semibold ${colors.heading}`}>
+        {icon}
+        {title}
+      </h4>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div key={item.text} className={`flex items-center gap-3 text-sm ${textColor}`}>
+            <item.icon className={`h-4 w-4 flex-shrink-0 ${iconColor}`} />
+            <span>{item.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/projects/purchase-rental-comparison/break-even-analysis-card.tsx
+++ b/src/components/projects/purchase-rental-comparison/break-even-analysis-card.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { TrendingUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
+import { formatBreakEvenDuration, type BreakEvenPhase } from '@/lib/utils/project/calculations'
+import { PHASE_LABELS, PHASE_ORDER } from './constants'
+
+interface ProjectedCosts {
+  purchase: number
+  rental: number
+  savings: number
+}
+
+interface BreakEvenAnalysisCardProps {
+  breakEvenYears: number
+  breakEvenMonths: number
+  breakEvenPhase: BreakEvenPhase
+  projectedCosts: ProjectedCosts
+  selectedTimeHorizon: number
+  monthly3ans: number
+  postThreeYearMonthly: number
+  annualRentalPrice: number
+  dynamicMax: number
+}
+
+/**
+ * Break-even analysis card with visual timeline and tiered cost display.
+ * @param props - Break-even data, projected costs, and rental pricing
+ * @returns Animated card with timeline, savings summary, and monthly cost breakdown
+ */
+export function BreakEvenAnalysisCard({
+  breakEvenYears,
+  breakEvenMonths,
+  breakEvenPhase,
+  projectedCosts,
+  selectedTimeHorizon,
+  monthly3ans,
+  postThreeYearMonthly,
+  annualRentalPrice,
+  dynamicMax,
+}: BreakEvenAnalysisCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.4 }}
+    >
+      <Card className="border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 shadow-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-3">
+            <div className="rounded-xl bg-gradient-to-br from-amber-100 to-orange-100 p-2">
+              <TrendingUp className="h-5 w-5 text-amber-600" />
+            </div>
+            Analyse de rentabilité
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2 text-center">
+            <div className="text-3xl font-bold text-amber-900">
+              {formatBreakEvenDuration(breakEvenMonths)}
+            </div>
+            <div className="text-sm text-amber-700">
+              Point d&apos;équilibre entre achat et location
+            </div>
+            <div className="text-xs text-amber-600">
+              Phase : {PHASE_LABELS[breakEvenPhase] ?? breakEvenPhase}
+            </div>
+          </div>
+
+          {/* Visual Timeline */}
+          <div className="space-y-2">
+            <div className="flex h-8 overflow-hidden rounded-lg">
+              {PHASE_ORDER.map((phase) => {
+                const isActive = phase === breakEvenPhase
+                const widthClass = phase === '3ans+' ? 'flex-[2]' : 'flex-1'
+
+                return (
+                  <div
+                    key={phase}
+                    className={cn(
+                      'flex items-center justify-center text-[10px] font-medium transition-all',
+                      isActive
+                        ? 'bg-amber-400 text-amber-900 ring-2 ring-amber-500 ring-offset-1'
+                        : 'bg-amber-100 text-amber-600',
+                      widthClass,
+                    )}
+                  >
+                    {PHASE_LABELS[phase]}
+                  </div>
+                )
+              })}
+            </div>
+            <div className="relative h-2">
+              <div
+                className="absolute top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-amber-600 shadow-sm"
+                style={{
+                  left: `${Math.min((breakEvenYears / Math.max(dynamicMax, breakEvenYears)) * 100, 100)}%`,
+                }}
+              />
+              <div className="h-px w-full bg-amber-200" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
+              <div className="mb-1 text-2xl font-bold text-amber-900">
+                {formatPriceHelper(Math.abs(projectedCosts.savings))}
+              </div>
+              <div className="text-sm text-amber-700">
+                {projectedCosts.savings >= 0 ? 'Économies' : 'Surcoût'} sur {selectedTimeHorizon} an
+                {selectedTimeHorizon > 1 ? 's' : ''}
+              </div>
+            </div>
+            <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
+              <div className="mb-1 text-2xl font-bold text-amber-900">
+                {projectedCosts.purchase > 0
+                  ? ((Math.abs(projectedCosts.savings) / projectedCosts.purchase) * 100).toFixed(1)
+                  : '0.0'}
+                %
+              </div>
+              <div className="text-sm text-amber-700">
+                {projectedCosts.savings >= 0 ? 'Économie' : 'Surcoût'} relatif
+              </div>
+            </div>
+            <div className="rounded-xl border border-white/50 bg-white/60 p-4 text-center">
+              {breakEvenPhase === '3ans+' ? (
+                <TieredMonthlyCost
+                  monthly3ans={monthly3ans}
+                  postThreeYearMonthly={postThreeYearMonthly}
+                />
+              ) : (
+                <SingleMonthlyCost
+                  monthly3ans={monthly3ans}
+                  annualRentalPrice={annualRentalPrice}
+                />
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}
+
+function TieredMonthlyCost({
+  monthly3ans,
+  postThreeYearMonthly,
+}: {
+  monthly3ans: number
+  postThreeYearMonthly: number
+}) {
+  return (
+    <>
+      <div className="mb-1 flex items-center justify-center gap-1.5">
+        <span className="text-lg font-bold text-amber-900">{formatPriceHelper(monthly3ans)}</span>
+        <Badge
+          variant="outline"
+          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
+        >
+          /mois
+        </Badge>
+      </div>
+      <div className="text-xs text-amber-700">3 premières années</div>
+      <div className="my-1 h-px bg-amber-200/50" />
+      <div className="flex items-center justify-center gap-1.5">
+        <span className="text-lg font-bold text-amber-900">
+          {formatPriceHelper(postThreeYearMonthly)}
+        </span>
+        <Badge
+          variant="outline"
+          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
+        >
+          /mois
+        </Badge>
+      </div>
+      <div className="text-xs text-amber-600">au-delà de 3 ans (20%)</div>
+    </>
+  )
+}
+
+function SingleMonthlyCost({
+  monthly3ans,
+  annualRentalPrice,
+}: {
+  monthly3ans: number
+  annualRentalPrice: number
+}) {
+  return (
+    <>
+      <div className="mb-1 flex items-center justify-center gap-1.5">
+        <span className="text-2xl font-bold text-amber-900">{formatPriceHelper(monthly3ans)}</span>
+        <Badge
+          variant="outline"
+          className="border-amber-400 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-600"
+        >
+          /mois
+        </Badge>
+      </div>
+      <div className="text-sm text-amber-700">Coût mensuel location</div>
+      <div className="mt-0.5 text-xs text-amber-500">
+        {formatPriceHelper(annualRentalPrice)} /an
+      </div>
+    </>
+  )
+}

--- a/src/components/projects/purchase-rental-comparison/break-even-analysis-card.tsx
+++ b/src/components/projects/purchase-rental-comparison/break-even-analysis-card.tsx
@@ -8,12 +8,7 @@ import { cn } from '@/lib/utils'
 import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
 import { formatBreakEvenDuration, type BreakEvenPhase } from '@/lib/utils/project/calculations'
 import { PHASE_LABELS, PHASE_ORDER } from './constants'
-
-interface ProjectedCosts {
-  purchase: number
-  rental: number
-  savings: number
-}
+import type { ProjectedCosts } from './types'
 
 interface BreakEvenAnalysisCardProps {
   breakEvenYears: number
@@ -42,7 +37,7 @@ export function BreakEvenAnalysisCard({
   postThreeYearMonthly,
   annualRentalPrice,
   dynamicMax,
-}: BreakEvenAnalysisCardProps) {
+}: Readonly<BreakEvenAnalysisCardProps>) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -146,13 +141,15 @@ export function BreakEvenAnalysisCard({
   )
 }
 
+interface TieredMonthlyCostProps {
+  monthly3ans: number
+  postThreeYearMonthly: number
+}
+
 function TieredMonthlyCost({
   monthly3ans,
   postThreeYearMonthly,
-}: {
-  monthly3ans: number
-  postThreeYearMonthly: number
-}) {
+}: Readonly<TieredMonthlyCostProps>) {
   return (
     <>
       <div className="mb-1 flex items-center justify-center gap-1.5">
@@ -182,13 +179,12 @@ function TieredMonthlyCost({
   )
 }
 
-function SingleMonthlyCost({
-  monthly3ans,
-  annualRentalPrice,
-}: {
+interface SingleMonthlyCostProps {
   monthly3ans: number
   annualRentalPrice: number
-}) {
+}
+
+function SingleMonthlyCost({ monthly3ans, annualRentalPrice }: Readonly<SingleMonthlyCostProps>) {
   return (
     <>
       <div className="mb-1 flex items-center justify-center gap-1.5">

--- a/src/components/projects/purchase-rental-comparison/constants.ts
+++ b/src/components/projects/purchase-rental-comparison/constants.ts
@@ -12,11 +12,12 @@ import {
   Calendar,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import type { BreakEvenPhase } from '@/lib/utils/project/calculations'
 
 export const DEFAULT_MAX_HORIZON = 9
 export const ABSOLUTE_MAX_HORIZON = 20
 
-export const PHASE_LABELS: Record<string, string> = {
+export const PHASE_LABELS: Record<BreakEvenPhase, string> = {
   '0-1an': '0 - 1 an',
   '1-2ans': '1 - 2 ans',
   '2-3ans': '2 - 3 ans',
@@ -26,11 +27,11 @@ export const PHASE_LABELS: Record<string, string> = {
 export const PHASE_ORDER = ['0-1an', '1-2ans', '2-3ans', '3ans+'] as const
 
 interface AdvantageItem {
-  icon: LucideIcon
-  text: string
+  readonly icon: LucideIcon
+  readonly text: string
 }
 
-export const PURCHASE_ADVANTAGES: AdvantageItem[] = [
+export const PURCHASE_ADVANTAGES: readonly AdvantageItem[] = [
   { icon: DollarSign, text: "Propriété complète de l'équipement" },
   { icon: TrendingUp, text: "Pas de coûts récurrents après l'achat" },
   { icon: Shield, text: "Contrôle total sur l'équipement" },
@@ -38,14 +39,14 @@ export const PURCHASE_ADVANTAGES: AdvantageItem[] = [
   { icon: Zap, text: 'Potentiel de revente en fin de vie' },
 ]
 
-export const PURCHASE_DISADVANTAGES: AdvantageItem[] = [
+export const PURCHASE_DISADVANTAGES: readonly AdvantageItem[] = [
   { icon: AlertCircle, text: 'Investissement initial important' },
   { icon: XCircle, text: 'Responsabilité maintenance et réparations' },
   { icon: Clock, text: 'Obsolescence technologique à votre charge' },
   { icon: Euro, text: 'Immobilisation de capital importante' },
 ]
 
-export const RENTAL_ADVANTAGES: AdvantageItem[] = [
+export const RENTAL_ADVANTAGES: readonly AdvantageItem[] = [
   { icon: Euro, text: 'Coût initial faible, étalement des paiements' },
   { icon: Shield, text: 'Maintenance incluse dans le service' },
   { icon: Zap, text: 'Flexibilité et mise à niveau possible' },
@@ -53,7 +54,7 @@ export const RENTAL_ADVANTAGES: AdvantageItem[] = [
   { icon: Calculator, text: 'Coûts prévisibles et budgétables' },
 ]
 
-export const RENTAL_DISADVANTAGES: AdvantageItem[] = [
+export const RENTAL_DISADVANTAGES: readonly AdvantageItem[] = [
   { icon: TrendingUp, text: 'Coût total plus élevé sur le long terme' },
   { icon: XCircle, text: "Pas de propriété de l'équipement" },
   { icon: Calendar, text: 'Contraintes contractuelles de durée' },

--- a/src/components/projects/purchase-rental-comparison/constants.ts
+++ b/src/components/projects/purchase-rental-comparison/constants.ts
@@ -1,0 +1,61 @@
+import {
+  Euro,
+  TrendingUp,
+  Clock,
+  XCircle,
+  AlertCircle,
+  Calculator,
+  Zap,
+  Shield,
+  Recycle,
+  DollarSign,
+  Calendar,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+export const DEFAULT_MAX_HORIZON = 9
+export const ABSOLUTE_MAX_HORIZON = 20
+
+export const PHASE_LABELS: Record<string, string> = {
+  '0-1an': '0 - 1 an',
+  '1-2ans': '1 - 2 ans',
+  '2-3ans': '2 - 3 ans',
+  '3ans+': 'au-delà de 3 ans',
+}
+
+export const PHASE_ORDER = ['0-1an', '1-2ans', '2-3ans', '3ans+'] as const
+
+interface AdvantageItem {
+  icon: LucideIcon
+  text: string
+}
+
+export const PURCHASE_ADVANTAGES: AdvantageItem[] = [
+  { icon: DollarSign, text: "Propriété complète de l'équipement" },
+  { icon: TrendingUp, text: "Pas de coûts récurrents après l'achat" },
+  { icon: Shield, text: "Contrôle total sur l'équipement" },
+  { icon: Calendar, text: 'Utilisation illimitée dans le temps' },
+  { icon: Zap, text: 'Potentiel de revente en fin de vie' },
+]
+
+export const PURCHASE_DISADVANTAGES: AdvantageItem[] = [
+  { icon: AlertCircle, text: 'Investissement initial important' },
+  { icon: XCircle, text: 'Responsabilité maintenance et réparations' },
+  { icon: Clock, text: 'Obsolescence technologique à votre charge' },
+  { icon: Euro, text: 'Immobilisation de capital importante' },
+]
+
+export const RENTAL_ADVANTAGES: AdvantageItem[] = [
+  { icon: Euro, text: 'Coût initial faible, étalement des paiements' },
+  { icon: Shield, text: 'Maintenance incluse dans le service' },
+  { icon: Zap, text: 'Flexibilité et mise à niveau possible' },
+  { icon: Recycle, text: 'Impact environnemental réduit' },
+  { icon: Calculator, text: 'Coûts prévisibles et budgétables' },
+]
+
+export const RENTAL_DISADVANTAGES: AdvantageItem[] = [
+  { icon: TrendingUp, text: 'Coût total plus élevé sur le long terme' },
+  { icon: XCircle, text: "Pas de propriété de l'équipement" },
+  { icon: Calendar, text: 'Contraintes contractuelles de durée' },
+  { icon: AlertCircle, text: 'Dépendance au fournisseur' },
+]

--- a/src/components/projects/purchase-rental-comparison/recommendation-section.tsx
+++ b/src/components/projects/purchase-rental-comparison/recommendation-section.tsx
@@ -7,12 +7,7 @@ import { Lightbulb, Home, ShoppingCart, ArrowRight } from 'lucide-react'
 import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
 import { formatBreakEvenDuration } from '@/lib/utils/project/calculations'
 import type { BreakEvenPhase } from '@/lib/utils/project/calculations'
-
-interface ProjectedCosts {
-  purchase: number
-  rental: number
-  savings: number
-}
+import type { ProjectedCosts } from './types'
 
 interface RecommendationSectionProps {
   recommendsRental: boolean
@@ -39,7 +34,7 @@ export function RecommendationSection({
   breakEvenYears,
   breakEvenMonths,
   projectKitCount,
-}: RecommendationSectionProps) {
+}: Readonly<RecommendationSectionProps>) {
   const recommendationText = buildRecommendationText({
     recommendsRental,
     selectedTimeHorizon,
@@ -96,6 +91,8 @@ export function RecommendationSection({
                 </p>
                 <div className="flex gap-3">
                   <Button
+                    disabled
+                    title="Bientot disponible"
                     className={
                       recommendsRental
                         ? 'bg-blue-500 hover:bg-blue-600'
@@ -105,7 +102,9 @@ export function RecommendationSection({
                     {recommendsRental ? 'Opter pour la location' : "Procéder à l'achat"}
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
-                  <Button variant="outline">Obtenir un devis détaillé</Button>
+                  <Button disabled title="Bientot disponible" variant="outline">
+                    Obtenir un devis détaillé
+                  </Button>
                 </div>
               </div>
             </div>

--- a/src/components/projects/purchase-rental-comparison/recommendation-section.tsx
+++ b/src/components/projects/purchase-rental-comparison/recommendation-section.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Lightbulb, Home, ShoppingCart, ArrowRight } from 'lucide-react'
+import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
+import { formatBreakEvenDuration } from '@/lib/utils/project/calculations'
+import type { BreakEvenPhase } from '@/lib/utils/project/calculations'
+
+interface ProjectedCosts {
+  purchase: number
+  rental: number
+  savings: number
+}
+
+interface RecommendationSectionProps {
+  recommendsRental: boolean
+  selectedTimeHorizon: number
+  projectedCosts: ProjectedCosts
+  breakEvenPhase: BreakEvenPhase | null
+  postThreeYearMonthly: number
+  breakEvenYears: number | null
+  breakEvenMonths: number | null
+  projectKitCount: number
+}
+
+/**
+ * Smart recommendation section comparing purchase vs rental with contextual advice.
+ * @param props - Recommendation state, costs, and project context
+ * @returns Recommendation card with action buttons and contextual factors
+ */
+export function RecommendationSection({
+  recommendsRental,
+  selectedTimeHorizon,
+  projectedCosts,
+  breakEvenPhase,
+  postThreeYearMonthly,
+  breakEvenYears,
+  breakEvenMonths,
+  projectKitCount,
+}: RecommendationSectionProps) {
+  const recommendationText = buildRecommendationText({
+    recommendsRental,
+    selectedTimeHorizon,
+    savings: projectedCosts.savings,
+    breakEvenPhase,
+    postThreeYearMonthly,
+  })
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.5 }}
+    >
+      <Card className="border-indigo-200 bg-gradient-to-br from-indigo-50 to-violet-50 shadow-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-3">
+            <div className="rounded-xl bg-gradient-to-br from-indigo-100 to-violet-100 p-2">
+              <Lightbulb className="h-5 w-5 text-indigo-600" />
+            </div>
+            Recommandation intelligente
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div
+            className={`rounded-xl border-2 p-6 ${
+              recommendsRental ? 'border-blue-300 bg-blue-50' : 'border-green-300 bg-green-50'
+            }`}
+          >
+            <div className="flex items-start gap-4">
+              <div
+                className={`rounded-xl p-2 ${recommendsRental ? 'bg-blue-100' : 'bg-green-100'}`}
+              >
+                {recommendsRental ? (
+                  <Home className="h-6 w-6 text-blue-600" />
+                ) : (
+                  <ShoppingCart className="h-6 w-6 text-green-600" />
+                )}
+              </div>
+              <div className="flex-1">
+                <h3
+                  className={`mb-2 text-lg font-bold ${
+                    recommendsRental ? 'text-blue-900' : 'text-green-900'
+                  }`}
+                >
+                  {recommendsRental ? 'Location recommandée' : 'Achat recommandé'}
+                </h3>
+                <p
+                  className={`mb-4 text-sm ${
+                    recommendsRental ? 'text-blue-800' : 'text-green-800'
+                  }`}
+                >
+                  {recommendationText}
+                </p>
+                <div className="flex gap-3">
+                  <Button
+                    className={
+                      recommendsRental
+                        ? 'bg-blue-500 hover:bg-blue-600'
+                        : 'bg-green-500 hover:bg-green-600'
+                    }
+                  >
+                    {recommendsRental ? 'Opter pour la location' : "Procéder à l'achat"}
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                  <Button variant="outline">Obtenir un devis détaillé</Button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
+            <div className="rounded-xl border border-white/50 bg-white/60 p-4">
+              <h4 className="mb-2 font-semibold text-indigo-900">Contexte de projet</h4>
+              <ul className="space-y-1 text-indigo-800">
+                <li>• {projectKitCount} types de kits configurés</li>
+                <li>
+                  • Durée d&apos;analyse : {selectedTimeHorizon} an
+                  {selectedTimeHorizon > 1 ? 's' : ''}
+                </li>
+                <li>
+                  •{' '}
+                  {breakEvenYears
+                    ? `Point d'équilibre : ${formatBreakEvenDuration(breakEvenMonths ?? breakEvenYears * 12)}`
+                    : 'Pas de données de location disponibles'}
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-white/50 bg-white/60 p-4">
+              <h4 className="mb-2 font-semibold text-indigo-900">Facteurs à considérer</h4>
+              <ul className="space-y-1 text-indigo-800">
+                <li>• Capacité d&apos;investissement initial</li>
+                <li>• Durée prévue d&apos;utilisation</li>
+                <li>• Besoins de flexibilité</li>
+                <li>• Évolution technologique prévue</li>
+              </ul>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}
+
+function buildRecommendationText({
+  recommendsRental,
+  selectedTimeHorizon,
+  savings,
+  breakEvenPhase,
+  postThreeYearMonthly,
+}: {
+  recommendsRental: boolean
+  selectedTimeHorizon: number
+  savings: number
+  breakEvenPhase: BreakEvenPhase | null
+  postThreeYearMonthly: number
+}): string {
+  const yearLabel = `${selectedTimeHorizon} an${selectedTimeHorizon > 1 ? 's' : ''}`
+  const savingsLabel = formatPriceHelper(Math.abs(savings))
+  const postRateLabel = formatPriceHelper(postThreeYearMonthly)
+  const showTieredNote = breakEvenPhase === '3ans+' && selectedTimeHorizon > 3
+
+  if (recommendsRental) {
+    const base = `Pour un projet de ${yearLabel}, la location vous permet d'économiser ${savingsLabel} tout en conservant votre flexibilité financière.`
+    if (showTieredNote) {
+      return `${base} Après 3 ans, le tarif de location passe à ${postRateLabel}/mois (20% du tarif initial).`
+    }
+    return base
+  }
+
+  const base = `Sur ${yearLabel}, l'achat vous permet d'économiser ${savingsLabel} et vous offre la propriété complète de l'équipement.`
+  if (showTieredNote) {
+    return `${base} Même avec le tarif réduit de ${postRateLabel}/mois après 3 ans, l'achat reste plus avantageux.`
+  }
+  return base
+}

--- a/src/components/projects/purchase-rental-comparison/rental-cost-breakdown.tsx
+++ b/src/components/projects/purchase-rental-comparison/rental-cost-breakdown.tsx
@@ -21,7 +21,7 @@ export function RentalCostBreakdown({
   monthly3ans,
   postThreeYearMonthly,
   annualRentalPrice,
-}: RentalCostBreakdownProps) {
+}: Readonly<RentalCostBreakdownProps>) {
   if (selectedTimeHorizon <= 3) {
     return (
       <>

--- a/src/components/projects/purchase-rental-comparison/rental-cost-breakdown.tsx
+++ b/src/components/projects/purchase-rental-comparison/rental-cost-breakdown.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { Badge } from '@/components/ui/badge'
+import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
+
+interface RentalCostBreakdownProps {
+  selectedTimeHorizon: number
+  monthly3ans: number
+  postThreeYearMonthly: number
+  annualRentalPrice: number
+}
+
+/**
+ * Two-tier monthly cost display for rental pricing.
+ * Shows a single rate for horizons <= 3 years and a breakdown for longer horizons.
+ * @param props - Monthly rates and time horizon for display logic
+ * @returns Rental cost breakdown with tier-specific formatting
+ */
+export function RentalCostBreakdown({
+  selectedTimeHorizon,
+  monthly3ans,
+  postThreeYearMonthly,
+  annualRentalPrice,
+}: RentalCostBreakdownProps) {
+  if (selectedTimeHorizon <= 3) {
+    return (
+      <>
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-blue-800">Coût mensuel</span>
+          <div className="flex items-center gap-1.5">
+            <span className="font-bold text-blue-900">{formatPriceHelper(monthly3ans)}</span>
+            <Badge
+              variant="outline"
+              className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
+            >
+              /mois
+            </Badge>
+          </div>
+        </div>
+        <div className="flex items-center justify-between text-xs text-blue-600">
+          <span>Coût annuel</span>
+          <span>{formatPriceHelper(annualRentalPrice)} /an</span>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-blue-800">Tarif 3 premières années</span>
+        <div className="flex items-center gap-1.5">
+          <span className="font-bold text-blue-900">{formatPriceHelper(monthly3ans)}</span>
+          <Badge
+            variant="outline"
+            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
+          >
+            /mois
+          </Badge>
+        </div>
+      </div>
+      <div className="h-px bg-blue-200/50"></div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-blue-800">Tarif au-delà de 3 ans</span>
+        <div className="flex items-center gap-1.5">
+          <span className="font-bold text-blue-900">{formatPriceHelper(postThreeYearMonthly)}</span>
+          <Badge
+            variant="outline"
+            className="border-blue-400 bg-blue-50 px-1.5 py-0 text-[10px] text-blue-600"
+          >
+            /mois
+          </Badge>
+        </div>
+      </div>
+      <div className="text-center text-xs text-blue-500">20% du tarif initial après 3 ans</div>
+    </>
+  )
+}

--- a/src/components/projects/purchase-rental-comparison/time-horizon-selector.tsx
+++ b/src/components/projects/purchase-rental-comparison/time-horizon-selector.tsx
@@ -26,7 +26,7 @@ export function TimeHorizonSelector({
   onSelect,
   isBreakEvenBeyondMax,
   breakEvenYears,
-}: TimeHorizonSelectorProps) {
+}: Readonly<TimeHorizonSelectorProps>) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}

--- a/src/components/projects/purchase-rental-comparison/time-horizon-selector.tsx
+++ b/src/components/projects/purchase-rental-comparison/time-horizon-selector.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Clock, AlertCircle } from 'lucide-react'
+import { formatBreakEvenDuration } from '@/lib/utils/project/calculations'
+import { ABSOLUTE_MAX_HORIZON } from './constants'
+
+interface TimeHorizonSelectorProps {
+  timeHorizons: number[]
+  selectedTimeHorizon: number
+  onSelect: (years: number) => void
+  isBreakEvenBeyondMax: boolean
+  breakEvenYears: number | null
+}
+
+/**
+ * Selector for the analysis time horizon with dynamic range and break-even warning.
+ * @param props - Time horizon options and selection state
+ * @returns Card with horizon buttons and optional beyond-max warning
+ */
+export function TimeHorizonSelector({
+  timeHorizons,
+  selectedTimeHorizon,
+  onSelect,
+  isBreakEvenBeyondMax,
+  breakEvenYears,
+}: TimeHorizonSelectorProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.1 }}
+    >
+      <Card className="border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 shadow-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-3">
+            <div className="rounded-xl bg-gradient-to-br from-purple-100 to-pink-100 p-2">
+              <Clock className="h-5 w-5 text-purple-600" />
+            </div>
+            Horizon temporel d&apos;analyse
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap justify-center gap-3">
+            {timeHorizons.map((years) => (
+              <Button
+                key={years}
+                variant={selectedTimeHorizon === years ? 'default' : 'outline'}
+                onClick={() => onSelect(years)}
+                className={selectedTimeHorizon === years ? 'bg-purple-500 hover:bg-purple-600' : ''}
+              >
+                {years} an{years > 1 ? 's' : ''}
+              </Button>
+            ))}
+          </div>
+          {isBreakEvenBeyondMax && (
+            <div className="flex items-center justify-center gap-2 text-sm text-amber-700">
+              <AlertCircle className="h-4 w-4" />
+              <span>
+                Le point d&apos;équilibre dépasse {ABSOLUTE_MAX_HORIZON} ans
+                {breakEvenYears !== null && ` (${formatBreakEvenDuration(breakEvenYears * 12)})`}
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/projects/purchase-rental-comparison/types.ts
+++ b/src/components/projects/purchase-rental-comparison/types.ts
@@ -1,0 +1,5 @@
+export interface ProjectedCosts {
+  purchase: number
+  rental: number
+  savings: number
+}

--- a/src/lib/utils/project/calculations.test.ts
+++ b/src/lib/utils/project/calculations.test.ts
@@ -18,6 +18,8 @@ import {
   calculateEnvironmentalSavings,
   calculateBreakEvenPoint,
   calculateExtendedRentalCost,
+  calculatePostThreeYearMonthly,
+  formatBreakEvenDuration,
 } from './calculations'
 
 describe('calculateProjectPriceTotals', () => {
@@ -464,5 +466,52 @@ describe('calculateBreakEvenPoint', () => {
     // With same rate, 3yr total = 10*12*3 = 360, purchase 5000 - 360 > 0 -> phase 3ans+
     expect(result!.phase).toBe('3ans+')
     expect(result!.breakEvenYears).toBeGreaterThan(3)
+  })
+})
+
+describe('calculatePostThreeYearMonthly', () => {
+  it('returns 20% of the base monthly rate, ceiled to the cent', () => {
+    // 9.09 * 0.2 = 1.818 -> ceil to 1.82
+    expect(calculatePostThreeYearMonthly(9.09)).toBe(1.82)
+  })
+
+  it('returns 0 for 0 input', () => {
+    expect(calculatePostThreeYearMonthly(0)).toBe(0)
+  })
+
+  it('handles exact multiples', () => {
+    // 10 * 0.2 = 2.00 -> 2.00
+    expect(calculatePostThreeYearMonthly(10)).toBe(2)
+  })
+})
+
+describe('formatBreakEvenDuration', () => {
+  it('formats exact years (no remaining months)', () => {
+    expect(formatBreakEvenDuration(12)).toBe('1 an')
+    expect(formatBreakEvenDuration(24)).toBe('2 ans')
+    expect(formatBreakEvenDuration(36)).toBe('3 ans')
+    expect(formatBreakEvenDuration(60)).toBe('5 ans')
+  })
+
+  it('formats months only when less than 12', () => {
+    expect(formatBreakEvenDuration(1)).toBe('1 mois')
+    expect(formatBreakEvenDuration(6)).toBe('6 mois')
+    expect(formatBreakEvenDuration(11)).toBe('11 mois')
+  })
+
+  it('formats mixed years and months', () => {
+    expect(formatBreakEvenDuration(18)).toBe('1 an et 6 mois')
+    expect(formatBreakEvenDuration(30)).toBe('2 ans et 6 mois')
+    expect(formatBreakEvenDuration(42)).toBe('3 ans et 6 mois')
+    expect(formatBreakEvenDuration(13)).toBe('1 an et 1 mois')
+  })
+
+  it('handles 0 months (edge case)', () => {
+    expect(formatBreakEvenDuration(0)).toBe('0 mois')
+  })
+
+  it('rounds remaining months to nearest integer', () => {
+    // 18.5 -> floor(18.5/12) = 1 year, round(18.5 % 12) = round(6.5) = 7
+    expect(formatBreakEvenDuration(18.5)).toBe('1 an et 7 mois')
   })
 })

--- a/src/lib/utils/project/calculations.ts
+++ b/src/lib/utils/project/calculations.ts
@@ -31,6 +31,9 @@ export interface KitBreakdownItem {
 
 export type BreakEvenPhase = '0-1an' | '1-2ans' | '2-3ans' | '3ans+'
 
+/** Rate applied after the initial 3-year rental period (20% of the base rate). */
+export const POST_THREE_YEAR_RATE = 0.2
+
 export interface BreakEvenResult {
   breakEvenMonths: number
   breakEvenYears: number
@@ -205,6 +208,15 @@ export function calculateEnvironmentalSavings(project: Project): EnvironmentalIm
 }
 
 /**
+ * Calculate the monthly rental rate applied after the initial 3-year period.
+ * @param monthlyBase3ans - Monthly rental price on a 3-year basis
+ * @returns Post-3-year monthly rate (20% of the base rate), ceiled to the cent
+ */
+export function calculatePostThreeYearMonthly(monthlyBase3ans: number): number {
+  return ceilPrice(monthlyBase3ans * POST_THREE_YEAR_RATE)
+}
+
+/**
  * Calculate the total rental cost for an extended duration using the tiered model:
  * - First 3 years: full monthly rate (base 3 ans)
  * - Beyond 3 years: 20% of the monthly rate (base 3 ans)
@@ -221,7 +233,7 @@ export function calculateExtendedRentalCost(monthlyBase3ans: number, years: numb
   }
 
   const baseThreeYearCost = ceilPrice(monthlyBase3ans * 12 * 3)
-  const postThreeYearMonthly = ceilPrice(monthlyBase3ans * 0.2)
+  const postThreeYearMonthly = calculatePostThreeYearMonthly(monthlyBase3ans)
   const extraYears = years - 3
   const postThreeYearCost = ceilPrice(postThreeYearMonthly * 12 * extraYears)
 
@@ -260,7 +272,7 @@ export function calculateBreakEvenPoint(project: Project): BreakEvenResult | nul
 
   // Case 1: Break-even beyond 3 years
   if (remainingAfter3Years > 0) {
-    const postMonthly = ceilPrice(effectiveMonthly3ans * 0.2)
+    const postMonthly = calculatePostThreeYearMonthly(effectiveMonthly3ans)
     if (postMonthly <= 0) return null
 
     const extraYears = remainingAfter3Years / (postMonthly * 12)
@@ -314,6 +326,24 @@ export function calculateBreakEvenPoint(project: Project): BreakEvenResult | nul
   }
 
   return null
+}
+
+/**
+ * Format a duration in months into a human-readable French string.
+ * @param months - Total duration in months
+ * @returns Formatted string (e.g., "3 ans et 6 mois", "1 an", "8 mois")
+ */
+export function formatBreakEvenDuration(months: number): string {
+  const years = Math.floor(months / 12)
+  const remainingMonths = Math.round(months % 12)
+
+  if (years === 0) {
+    return `${remainingMonths} mois`
+  }
+  if (remainingMonths === 0) {
+    return `${years} an${years > 1 ? 's' : ''}`
+  }
+  return `${years} an${years > 1 ? 's' : ''} et ${remainingMonths} mois`
 }
 
 function calculateCostsForMode(


### PR DESCRIPTION
## Summary

- Update `PurchaseRentalComparison` component to integrate the new tiered pricing model (full rate for 3 years, 20% beyond) from TRI-103/TRI-104
- Replace linear rental cost calculation with `calculateExtendedRentalCost()` and display two-tier monthly breakdown
- Add dynamic time horizon slider, break-even phase timeline, and enhanced recommendation logic

## Related Issue

TRI-105

## Changes

### Tiered Pricing Integration
- Replace linear `rentalCostPerYear * years` with `calculateExtendedRentalCost()` for accurate tiered calculation
- Import and use `ceilPrice` for consistent rounding in displayed values

### Dynamic Time Horizon Slider
- Auto-adapt slider range based on break-even point (up to 20 years max)
- Show warning when break-even exceeds 20 years with exact duration

### Two-Tier Monthly Cost Display
- Show single rate for horizons <= 3 years
- Show two-tier breakdown (full rate + 20% rate) for horizons > 3 years
- Display effective average monthly rate as headline

### Break-Even Phase Display + Visual Timeline
- Display break-even in years + months format (e.g., "3 ans et 6 mois")
- Show phase label (0-1 an, 1-2 ans, 2-3 ans, au-delà de 3 ans)
- Add 4-segment visual timeline bar highlighting the active phase
- Show two-tier monthly costs in break-even card when phase is 3ans+

### Recommendation Logic
- Add tiered pricing context to recommendation text
- Mention reduced post-3-year rate when relevant

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [ ] Unit tests pass (no test runner configured)
- [x] Manual testing done (Chrome DevTools MCP — tested at 1, 3, 5, 20 years + mobile responsive)

## Screenshots (if UI changes)

Tested at multiple time horizons (1 an, 3 ans, 5 ans, 20 ans) and on mobile viewport (390x844). All tiered pricing calculations verified manually.
