### PR TITLE
feat(api): restrict cost and margin field visibility to admin/dev roles

### DIFF
--- a/src/app/api/kits/[id]/route.ts
+++ b/src/app/api/kits/[id]/route.ts
@@ -11,6 +11,8 @@ import {
 } from '@/lib/api/middleware'
 import { groupDuplicateProducts } from '@/lib/utils/kit/group-products'
 import { validateProductsExist, KIT_WITH_PRODUCTS_INCLUDE } from '@/lib/services/kit.service'
+import { isAdminOrDev } from '@/lib/utils/roles'
+import { stripCostFieldsDeep } from '@/lib/utils/strip-cost-fields'
 
 // GET /api/kits/[id] - Récupérer un kit par ID
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -27,8 +29,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: 'Kit non trouvé' }, { status: 404 })
     }
 
+    const visibleKit = isAdminOrDev(auth.user.role) ? kit : stripCostFieldsDeep(kit)
+
     // Configure cache headers for this response
-    const response = NextResponse.json(kit)
+    const response = NextResponse.json(visibleKit)
     setResourceCacheHeaders(response, CACHE_CONFIG.KITS, 5)
 
     return response

--- a/src/app/api/kits/route.ts
+++ b/src/app/api/kits/route.ts
@@ -11,6 +11,8 @@ import {
 } from '@/lib/api/middleware'
 import { groupDuplicateProducts } from '@/lib/utils/kit/group-products'
 import { validateProductsExist, KIT_WITH_PRODUCTS_INCLUDE } from '@/lib/services/kit.service'
+import { isAdminOrDev } from '@/lib/utils/roles'
+import { stripCostFieldsDeep } from '@/lib/utils/strip-cost-fields'
 
 // GET /api/kits - Liste des kits
 export async function GET(request: NextRequest) {
@@ -26,8 +28,10 @@ export async function GET(request: NextRequest) {
     // Use cached function for better performance with optional filters
     const kits = await getKits({ search, style })
 
+    const visibleKits = isAdminOrDev(auth.user.role) ? kits : kits.map(stripCostFieldsDeep)
+
     // Configure cache headers for this response
-    const response = NextResponse.json(kits)
+    const response = NextResponse.json(visibleKits)
     setResourceCacheHeaders(response, CACHE_CONFIG.KITS, 5)
 
     return response

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -10,6 +10,8 @@ import {
   setResourceCacheHeaders,
 } from '@/lib/api/middleware'
 import { remapProductFormFields } from '@/lib/utils/product/map-form-fields'
+import { isAdminOrDev } from '@/lib/utils/roles'
+import { stripCostFieldsFromProduct } from '@/lib/utils/strip-cost-fields'
 
 // GET /api/products/[id] - Récupérer un produit par ID
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -26,8 +28,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: 'Produit non trouvé' }, { status: 404 })
     }
 
+    const visibleProduct = isAdminOrDev(auth.user.role)
+      ? product
+      : stripCostFieldsFromProduct(product)
+
     // Configure cache headers for this response
-    const response = NextResponse.json(product)
+    const response = NextResponse.json(visibleProduct)
     setResourceCacheHeaders(response, CACHE_CONFIG.PRODUCTS)
 
     return response
@@ -56,7 +62,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     const validatedData = productUpdateSchema.parse({ ...body, id })
 
     // Retirer l'ID des données à mettre à jour
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     const { id: _id, ...updateData } = validatedData
 
     // Vérifier que la référence n'existe pas déjà (si elle est modifiée)

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -5,6 +5,8 @@ import { UserRole } from '@/lib/types/user'
 import { prisma } from '@/lib/db'
 import { invalidateProducts, CACHE_CONFIG } from '@/lib/cache'
 import { requireAuth, requireRole, handleApiError, setListCacheHeaders } from '@/lib/api/middleware'
+import { isAdminOrDev } from '@/lib/utils/roles'
+import { stripCostFieldsFromProduct } from '@/lib/utils/strip-cost-fields'
 
 // GET /api/products - Liste des produits avec filtres
 export async function GET(request: NextRequest) {
@@ -79,8 +81,12 @@ export async function GET(request: NextRequest) {
         },
       })
 
+      const visibleProducts = isAdminOrDev(auth.user.role)
+        ? products
+        : products.map(stripCostFieldsFromProduct)
+
       return NextResponse.json({
-        products,
+        products: visibleProducts,
         pagination: {
           page: 1,
           limit: products.length,
@@ -118,9 +124,13 @@ export async function GET(request: NextRequest) {
 
     const totalPages = Math.ceil(total / filters.limit)
 
+    const visibleProducts = isAdminOrDev(auth.user.role)
+      ? products
+      : products.map(stripCostFieldsFromProduct)
+
     // Configure cache for this response
     const response = NextResponse.json({
-      products,
+      products: visibleProducts,
       pagination: {
         page: filters.page,
         limit: filters.limit,

--- a/src/app/api/projects/[id]/kits/route.ts
+++ b/src/app/api/projects/[id]/kits/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/services/project-history'
 import { verifyProjectAccess } from '@/lib/utils/project/access'
 import { requireAuth, handleApiError } from '@/lib/api/middleware'
+import { stripCostFieldsDeep } from '@/lib/utils/strip-cost-fields'
 import { projectKitsSchema } from '@/lib/schemas/project'
 import { logger } from '@/lib/logger'
 
@@ -152,7 +153,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       },
     })
 
-    return NextResponse.json(projectKits)
+    const visibleKits = access.data.isAdmin ? projectKits : projectKits.map(stripCostFieldsDeep)
+
+    return NextResponse.json(visibleKits)
   } catch (error) {
     return handleApiError(error)
   }

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -12,6 +12,7 @@ import {
 import { requireAuth, handleApiError } from '@/lib/api/middleware'
 import { updateProjectSchema, replaceProjectSchema } from '@/lib/schemas/project'
 import { logger } from '@/lib/logger'
+import { stripCostFieldsDeep } from '@/lib/utils/strip-cost-fields'
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -52,10 +53,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // Calculer les totaux
     const totals = calculateProjectTotals(project as unknown as Project)
 
-    return NextResponse.json({
-      ...project,
-      ...totals,
-    })
+    const responseData = { ...project, ...totals }
+
+    return NextResponse.json(access.data.isAdmin ? responseData : stripCostFieldsDeep(responseData))
   } catch (error) {
     return handleApiError(error)
   }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { getProjects, createProject, prisma } from '@/lib/db'
 import { calculateProjectTotals } from '@/lib/services/project.service'
-import { UserRole } from '@/lib/types/user'
 import { createProjectCreatedHistory } from '@/lib/services/project-history'
 import { requireAuth, handleApiError } from '@/lib/api/middleware'
 import { createProjectSchema } from '@/lib/schemas/project'
+import { isAdminOrDev } from '@/lib/utils/roles'
 import { stripCostFieldsDeep } from '@/lib/utils/strip-cost-fields'
 
 export async function GET(request: NextRequest) {
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     const auth = await requireAuth(request)
     if (auth.response) return auth.response
 
-    const isAdmin = auth.user.role === UserRole.ADMIN || auth.user.role === UserRole.DEV
+    const isAdmin = isAdminOrDev(auth.user.role)
 
     // Récupérer le paramètre userId depuis l'URL
     const url = new URL(request.url)

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -6,6 +6,7 @@ import { UserRole } from '@/lib/types/user'
 import { createProjectCreatedHistory } from '@/lib/services/project-history'
 import { requireAuth, handleApiError } from '@/lib/api/middleware'
 import { createProjectSchema } from '@/lib/schemas/project'
+import { stripCostFieldsDeep } from '@/lib/utils/strip-cost-fields'
 
 export async function GET(request: NextRequest) {
   try {
@@ -44,7 +45,11 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    return NextResponse.json(projectsWithTotals)
+    const visibleProjects = isAdmin
+      ? projectsWithTotals
+      : projectsWithTotals.map(stripCostFieldsDeep)
+
+    return NextResponse.json(visibleProjects)
   } catch (error) {
     return handleApiError(error)
   }

--- a/src/components/projects/pricing-detailed-analysis.tsx
+++ b/src/components/projects/pricing-detailed-analysis.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
+import { useCanViewCosts } from '@/hooks/use-can-view-costs'
 import { motion } from 'framer-motion'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -46,6 +47,7 @@ interface PricingDetailedAnalysisProps {
  * @returns The rendered detailed analysis view
  */
 export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProps) {
+  const canViewCosts = useCanViewCosts()
   const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('achat')
   const [selectedPeriod, setSelectedPeriod] = useState<ProductPeriod>('1an')
   const [selectedHorizon, setSelectedHorizon] = useState(5)
@@ -137,7 +139,7 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
-        className="grid grid-cols-1 gap-6 md:grid-cols-3"
+        className={`grid grid-cols-1 gap-6 ${canViewCosts ? 'md:grid-cols-3' : 'md:grid-cols-1'}`}
       >
         <motion.div
           whileHover={{ y: -2, scale: 1.02 }}
@@ -170,67 +172,71 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
           </div>
         </motion.div>
 
-        <motion.div
-          whileHover={{ y: -2, scale: 1.02 }}
-          className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-8 text-center shadow-sm transition-all duration-300"
-        >
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-500/[0.02] to-indigo-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-          <div className="relative z-10">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-blue-100 to-indigo-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
-              <Calculator className="h-8 w-8 text-blue-600" />
+        {canViewCosts && (
+          <motion.div
+            whileHover={{ y: -2, scale: 1.02 }}
+            className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-8 text-center shadow-sm transition-all duration-300"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/[0.02] to-indigo-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+            <div className="relative z-10">
+              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-blue-100 to-indigo-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
+                <Calculator className="h-8 w-8 text-blue-600" />
+              </div>
+              {selectedMode === 'location' ? (
+                <LocationPriceDisplay
+                  annualPrice={currentData.totalCost}
+                  label="Coût total"
+                  variant="card"
+                  priceClassName="text-blue-900 text-4xl"
+                  secondaryClassName="text-blue-600"
+                  labelClassName="text-blue-700 text-base font-semibold"
+                  badgeClassName="border-blue-500 text-blue-600 bg-blue-50"
+                  secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
+                />
+              ) : (
+                <>
+                  <div className="mb-2 text-4xl font-bold text-blue-900">
+                    {formatPriceHelper(currentData.totalCost)}
+                  </div>
+                  <div className="text-base font-semibold text-blue-700">Coût total</div>
+                </>
+              )}
             </div>
-            {selectedMode === 'location' ? (
-              <LocationPriceDisplay
-                annualPrice={currentData.totalCost}
-                label="Coût total"
-                variant="card"
-                priceClassName="text-blue-900 text-4xl"
-                secondaryClassName="text-blue-600"
-                labelClassName="text-blue-700 text-base font-semibold"
-                badgeClassName="border-blue-500 text-blue-600 bg-blue-50"
-                secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
-              />
-            ) : (
-              <>
-                <div className="mb-2 text-4xl font-bold text-blue-900">
-                  {formatPriceHelper(currentData.totalCost)}
-                </div>
-                <div className="text-base font-semibold text-blue-700">Coût total</div>
-              </>
-            )}
-          </div>
-        </motion.div>
+          </motion.div>
+        )}
 
-        <motion.div
-          whileHover={{ y: -2, scale: 1.02 }}
-          className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50 p-8 text-center shadow-sm transition-all duration-300"
-        >
-          <div className="absolute inset-0 bg-gradient-to-br from-purple-500/[0.02] to-violet-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-          <div className="relative z-10">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-purple-100 to-violet-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
-              <TrendingUp className="h-8 w-8 text-purple-600" />
+        {canViewCosts && (
+          <motion.div
+            whileHover={{ y: -2, scale: 1.02 }}
+            className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50 p-8 text-center shadow-sm transition-all duration-300"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-purple-500/[0.02] to-violet-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+            <div className="relative z-10">
+              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-purple-100 to-violet-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
+                <TrendingUp className="h-8 w-8 text-purple-600" />
+              </div>
+              {selectedMode === 'location' ? (
+                <LocationPriceDisplay
+                  annualPrice={currentData.totalMargin}
+                  label="Marge totale"
+                  variant="card"
+                  priceClassName="text-purple-900 text-4xl"
+                  secondaryClassName="text-purple-600"
+                  labelClassName="text-purple-700 text-base font-semibold"
+                  badgeClassName="border-purple-500 text-purple-600 bg-purple-50"
+                  secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
+                />
+              ) : (
+                <>
+                  <div className="mb-2 text-4xl font-bold text-purple-900">
+                    {formatPriceHelper(currentData.totalMargin)}
+                  </div>
+                  <div className="text-base font-semibold text-purple-700">Marge totale</div>
+                </>
+              )}
             </div>
-            {selectedMode === 'location' ? (
-              <LocationPriceDisplay
-                annualPrice={currentData.totalMargin}
-                label="Marge totale"
-                variant="card"
-                priceClassName="text-purple-900 text-4xl"
-                secondaryClassName="text-purple-600"
-                labelClassName="text-purple-700 text-base font-semibold"
-                badgeClassName="border-purple-500 text-purple-600 bg-purple-50"
-                secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
-              />
-            ) : (
-              <>
-                <div className="mb-2 text-4xl font-bold text-purple-900">
-                  {formatPriceHelper(currentData.totalMargin)}
-                </div>
-                <div className="text-base font-semibold text-purple-700">Marge totale</div>
-              </>
-            )}
-          </div>
-        </motion.div>
+          </motion.div>
+        )}
       </motion.div>
 
       <motion.div
@@ -263,75 +269,80 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
               </Badge>
             </div>
 
-            <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
-                  <span className="text-sm font-medium text-amber-800">Marge brute</span>
-                  <span className="text-xl font-bold text-amber-900">
-                    {marginPercentage.toFixed(1)}%
-                  </span>
-                </div>
+            <div className={`grid grid-cols-1 gap-8 ${canViewCosts ? 'md:grid-cols-2' : ''}`}>
+              {canViewCosts && (
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
+                    <span className="text-sm font-medium text-amber-800">Marge brute</span>
+                    <span className="text-xl font-bold text-amber-900">
+                      {marginPercentage.toFixed(1)}%
+                    </span>
+                  </div>
 
-                <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
-                  <Progress value={Math.min(marginPercentage, 100)} className="h-4 bg-amber-100" />
-                </div>
+                  <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
+                    <Progress
+                      value={Math.min(marginPercentage, 100)}
+                      className="h-4 bg-amber-100"
+                    />
+                  </div>
 
-                <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
-                  <div className="space-y-3 text-sm text-amber-700">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium">Coût</span>
-                      <div className="text-right">
-                        <span className="font-semibold text-amber-900">
-                          {formatPriceHelper(
-                            selectedMode === 'location'
-                              ? annualToMonthly(currentData.totalCost)
-                              : currentData.totalCost,
+                  <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
+                    <div className="space-y-3 text-sm text-amber-700">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium">Coût</span>
+                        <div className="text-right">
+                          <span className="font-semibold text-amber-900">
+                            {formatPriceHelper(
+                              selectedMode === 'location'
+                                ? annualToMonthly(currentData.totalCost)
+                                : currentData.totalCost,
+                            )}
+                          </span>
+                          {selectedMode === 'location' && (
+                            <span className="ml-1 text-xs text-amber-600">/mois</span>
                           )}
-                        </span>
-                        {selectedMode === 'location' && (
-                          <span className="ml-1 text-xs text-amber-600">/mois</span>
-                        )}
+                        </div>
                       </div>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium">Marge</span>
-                      <div className="text-right">
-                        <span className="font-semibold text-amber-900">
-                          {formatPriceHelper(
-                            selectedMode === 'location'
-                              ? annualToMonthly(currentData.totalMargin)
-                              : currentData.totalMargin,
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium">Marge</span>
+                        <div className="text-right">
+                          <span className="font-semibold text-amber-900">
+                            {formatPriceHelper(
+                              selectedMode === 'location'
+                                ? annualToMonthly(currentData.totalMargin)
+                                : currentData.totalMargin,
+                            )}
+                          </span>
+                          {selectedMode === 'location' && (
+                            <span className="ml-1 text-xs text-amber-600">/mois</span>
                           )}
-                        </span>
-                        {selectedMode === 'location' && (
-                          <span className="ml-1 text-xs text-amber-600">/mois</span>
-                        )}
+                        </div>
                       </div>
-                    </div>
-                    <div className="h-px bg-amber-200"></div>
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold">Prix de vente</span>
-                      <div className="text-right">
-                        <span className="font-bold text-amber-900">
-                          {formatPriceHelper(
-                            selectedMode === 'location'
-                              ? annualToMonthly(currentData.totalPrice)
-                              : currentData.totalPrice,
+                      <div className="h-px bg-amber-200"></div>
+                      <div className="flex items-center justify-between">
+                        <span className="font-semibold">Prix de vente</span>
+                        <div className="text-right">
+                          <span className="font-bold text-amber-900">
+                            {formatPriceHelper(
+                              selectedMode === 'location'
+                                ? annualToMonthly(currentData.totalPrice)
+                                : currentData.totalPrice,
+                            )}
+                          </span>
+                          {selectedMode === 'location' && (
+                            <span className="ml-1 text-xs text-amber-600">/mois</span>
                           )}
-                        </span>
-                        {selectedMode === 'location' && (
-                          <span className="ml-1 text-xs text-amber-600">/mois</span>
-                        )}
+                        </div>
                       </div>
+                      {selectedMode === 'location' && (
+                        <div className="pt-1 text-right text-xs text-amber-500">
+                          {formatPriceHelper(currentData.totalPrice)} /an
+                        </div>
+                      )}
                     </div>
-                    {selectedMode === 'location' && (
-                      <div className="pt-1 text-right text-xs text-amber-500">
-                        {formatPriceHelper(currentData.totalPrice)} /an
-                      </div>
-                    )}
                   </div>
                 </div>
-              </div>
+              )}
 
               <div className="space-y-4">
                 <div className="rounded-2xl border border-amber-200 bg-gradient-to-br from-white to-amber-50 p-6 text-center shadow-sm">
@@ -411,21 +422,23 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
                           <p className="text-sm text-gray-500">Quantité: {kit.quantity}</p>
                         </div>
                       </div>
-                      <Badge
-                        variant="outline"
-                        className={`text-sm font-medium ${
-                          kit.marginPercentage > 30
-                            ? 'border-green-500 bg-green-50 text-green-700'
-                            : kit.marginPercentage > 20
-                              ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
-                              : 'border-red-500 bg-red-50 text-red-700'
-                        }`}
-                      >
-                        {kit.marginPercentage.toFixed(1)}% marge
-                      </Badge>
+                      {canViewCosts && (
+                        <Badge
+                          variant="outline"
+                          className={`text-sm font-medium ${
+                            kit.marginPercentage > 30
+                              ? 'border-green-500 bg-green-50 text-green-700'
+                              : kit.marginPercentage > 20
+                                ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
+                                : 'border-red-500 bg-red-50 text-red-700'
+                          }`}
+                        >
+                          {kit.marginPercentage.toFixed(1)}% marge
+                        </Badge>
+                      )}
                     </div>
 
-                    <div className="grid grid-cols-3 gap-4">
+                    <div className={`grid gap-4 ${canViewCosts ? 'grid-cols-3' : 'grid-cols-1'}`}>
                       <div className="rounded-xl border border-green-100 bg-gradient-to-br from-green-50 to-emerald-50 p-4 text-center">
                         {selectedMode === 'location' ? (
                           <LocationPriceDisplay
@@ -447,48 +460,52 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
                           </>
                         )}
                       </div>
-                      <div className="rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50 to-indigo-50 p-4 text-center">
-                        {selectedMode === 'location' ? (
-                          <LocationPriceDisplay
-                            annualPrice={kit.totalCost}
-                            label="Coût total"
-                            variant="card"
-                            priceClassName="text-blue-900 text-lg"
-                            secondaryClassName="text-blue-600 text-xs"
-                            labelClassName="text-blue-700 text-xs"
-                            badgeClassName="border-blue-500 text-blue-600 bg-blue-50 text-[10px] px-1 py-0"
-                            secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
-                          />
-                        ) : (
-                          <>
-                            <div className="mb-1 text-lg font-bold text-blue-900">
-                              {formatPriceHelper(kit.totalCost)}
-                            </div>
-                            <div className="text-xs font-medium text-blue-700">Coût total</div>
-                          </>
-                        )}
-                      </div>
-                      <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-violet-50 p-4 text-center">
-                        {selectedMode === 'location' ? (
-                          <LocationPriceDisplay
-                            annualPrice={kit.totalMargin}
-                            label="Marge"
-                            variant="card"
-                            priceClassName="text-purple-900 text-lg"
-                            secondaryClassName="text-purple-600 text-xs"
-                            labelClassName="text-purple-700 text-xs"
-                            badgeClassName="border-purple-500 text-purple-600 bg-purple-50 text-[10px] px-1 py-0"
-                            secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
-                          />
-                        ) : (
-                          <>
-                            <div className="mb-1 text-lg font-bold text-purple-900">
-                              {formatPriceHelper(kit.totalMargin)}
-                            </div>
-                            <div className="text-xs font-medium text-purple-700">Marge</div>
-                          </>
-                        )}
-                      </div>
+                      {canViewCosts && (
+                        <div className="rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50 to-indigo-50 p-4 text-center">
+                          {selectedMode === 'location' ? (
+                            <LocationPriceDisplay
+                              annualPrice={kit.totalCost}
+                              label="Coût total"
+                              variant="card"
+                              priceClassName="text-blue-900 text-lg"
+                              secondaryClassName="text-blue-600 text-xs"
+                              labelClassName="text-blue-700 text-xs"
+                              badgeClassName="border-blue-500 text-blue-600 bg-blue-50 text-[10px] px-1 py-0"
+                              secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
+                            />
+                          ) : (
+                            <>
+                              <div className="mb-1 text-lg font-bold text-blue-900">
+                                {formatPriceHelper(kit.totalCost)}
+                              </div>
+                              <div className="text-xs font-medium text-blue-700">Coût total</div>
+                            </>
+                          )}
+                        </div>
+                      )}
+                      {canViewCosts && (
+                        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-violet-50 p-4 text-center">
+                          {selectedMode === 'location' ? (
+                            <LocationPriceDisplay
+                              annualPrice={kit.totalMargin}
+                              label="Marge"
+                              variant="card"
+                              priceClassName="text-purple-900 text-lg"
+                              secondaryClassName="text-purple-600 text-xs"
+                              labelClassName="text-purple-700 text-xs"
+                              badgeClassName="border-purple-500 text-purple-600 bg-purple-50 text-[10px] px-1 py-0"
+                              secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
+                            />
+                          ) : (
+                            <>
+                              <div className="mb-1 text-lg font-bold text-purple-900">
+                                {formatPriceHelper(kit.totalMargin)}
+                              </div>
+                              <div className="text-xs font-medium text-purple-700">Marge</div>
+                            </>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </motion.div>
                 ))}
@@ -533,13 +550,21 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
                       <th className="px-4 py-3 text-right font-semibold text-gray-700">
                         Prix /mois
                       </th>
-                      <th className="px-4 py-3 text-right font-semibold text-gray-700">
-                        Coût /mois
-                      </th>
-                      <th className="px-4 py-3 text-right font-semibold text-gray-700">
-                        Marge /mois
-                      </th>
-                      <th className="px-4 py-3 text-right font-semibold text-gray-700">Marge %</th>
+                      {canViewCosts && (
+                        <th className="px-4 py-3 text-right font-semibold text-gray-700">
+                          Coût /mois
+                        </th>
+                      )}
+                      {canViewCosts && (
+                        <th className="px-4 py-3 text-right font-semibold text-gray-700">
+                          Marge /mois
+                        </th>
+                      )}
+                      {canViewCosts && (
+                        <th className="px-4 py-3 text-right font-semibold text-gray-700">
+                          Marge %
+                        </th>
+                      )}
                     </tr>
                   </thead>
                   <tbody>
@@ -571,36 +596,42 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
                               {formatPriceHelper(prices.totalPrice)} /an
                             </div>
                           </td>
-                          <td className="px-4 py-4 text-right">
-                            <div className="text-gray-600">
-                              {formatPriceHelper(annualToMonthly(prices.totalCost))}
-                            </div>
-                            <div className="text-xs text-gray-400">
-                              {formatPriceHelper(prices.totalCost)} /an
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 text-right">
-                            <div className="font-medium text-green-600">
-                              {formatPriceHelper(annualToMonthly(prices.totalMargin))}
-                            </div>
-                            <div className="text-xs text-gray-400">
-                              {formatPriceHelper(prices.totalMargin)} /an
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 text-right">
-                            <Badge
-                              variant="outline"
-                              className={`font-medium ${
-                                marginPercent > 30
-                                  ? 'border-green-500 bg-green-50 text-green-700'
-                                  : marginPercent > 20
-                                    ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
-                                    : 'border-red-500 bg-red-50 text-red-700'
-                              }`}
-                            >
-                              {marginPercent.toFixed(1)}%
-                            </Badge>
-                          </td>
+                          {canViewCosts && (
+                            <td className="px-4 py-4 text-right">
+                              <div className="text-gray-600">
+                                {formatPriceHelper(annualToMonthly(prices.totalCost))}
+                              </div>
+                              <div className="text-xs text-gray-400">
+                                {formatPriceHelper(prices.totalCost)} /an
+                              </div>
+                            </td>
+                          )}
+                          {canViewCosts && (
+                            <td className="px-4 py-4 text-right">
+                              <div className="font-medium text-green-600">
+                                {formatPriceHelper(annualToMonthly(prices.totalMargin))}
+                              </div>
+                              <div className="text-xs text-gray-400">
+                                {formatPriceHelper(prices.totalMargin)} /an
+                              </div>
+                            </td>
+                          )}
+                          {canViewCosts && (
+                            <td className="px-4 py-4 text-right">
+                              <Badge
+                                variant="outline"
+                                className={`font-medium ${
+                                  marginPercent > 30
+                                    ? 'border-green-500 bg-green-50 text-green-700'
+                                    : marginPercent > 20
+                                      ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
+                                      : 'border-red-500 bg-red-50 text-red-700'
+                                }`}
+                              >
+                                {marginPercent.toFixed(1)}%
+                              </Badge>
+                            </td>
+                          )}
                         </tr>
                       )
                     })}
@@ -637,30 +668,31 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
                   Analyse et recommandations
                 </h3>
                 <div className="space-y-3 text-sm text-indigo-800">
-                  {marginPercentage > 30 ? (
-                    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                      <div className="h-2 w-2 flex-shrink-0 rounded-full bg-green-500"></div>
-                      <span className="font-medium">
-                        Excellente rentabilité ! Votre marge de {marginPercentage.toFixed(1)}% est
-                        très bonne.
-                      </span>
-                    </div>
-                  ) : marginPercentage > 20 ? (
-                    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                      <div className="h-2 w-2 flex-shrink-0 rounded-full bg-yellow-500"></div>
-                      <span className="font-medium">
-                        Rentabilité correcte. Considérez optimiser les coûts pour améliorer la
-                        marge.
-                      </span>
-                    </div>
-                  ) : (
-                    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                      <div className="h-2 w-2 flex-shrink-0 rounded-full bg-red-500"></div>
-                      <span className="font-medium">
-                        Marge faible. Analysez les coûts et considérez ajuster les prix.
-                      </span>
-                    </div>
-                  )}
+                  {canViewCosts &&
+                    (marginPercentage > 30 ? (
+                      <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
+                        <div className="h-2 w-2 flex-shrink-0 rounded-full bg-green-500"></div>
+                        <span className="font-medium">
+                          Excellente rentabilité ! Votre marge de {marginPercentage.toFixed(1)}% est
+                          très bonne.
+                        </span>
+                      </div>
+                    ) : marginPercentage > 20 ? (
+                      <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
+                        <div className="h-2 w-2 flex-shrink-0 rounded-full bg-yellow-500"></div>
+                        <span className="font-medium">
+                          Rentabilité correcte. Considérez optimiser les coûts pour améliorer la
+                          marge.
+                        </span>
+                      </div>
+                    ) : (
+                      <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
+                        <div className="h-2 w-2 flex-shrink-0 rounded-full bg-red-500"></div>
+                        <span className="font-medium">
+                          Marge faible. Analysez les coûts et considérez ajuster les prix.
+                        </span>
+                      </div>
+                    ))}
 
                   <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
                     <div className="h-2 w-2 flex-shrink-0 rounded-full bg-blue-500"></div>
@@ -669,16 +701,18 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
                     </span>
                   </div>
 
-                  <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                    <div className="h-2 w-2 flex-shrink-0 rounded-full bg-purple-500"></div>
-                    <span className="font-medium">
-                      {selectedMode === 'achat'
-                        ? `Coût total pour l'achat : ${formatPriceHelper(currentData.totalCost)}`
-                        : `Coût total pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()} : ${formatPriceHelper(currentData.totalCost)}`}
-                    </span>
-                  </div>
+                  {canViewCosts && (
+                    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
+                      <div className="h-2 w-2 flex-shrink-0 rounded-full bg-purple-500"></div>
+                      <span className="font-medium">
+                        {selectedMode === 'achat'
+                          ? `Coût total pour l'achat : ${formatPriceHelper(currentData.totalCost)}`
+                          : `Coût total pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()} : ${formatPriceHelper(currentData.totalCost)}`}
+                      </span>
+                    </div>
+                  )}
 
-                  {kitBreakdown.length > 0 && (
+                  {canViewCosts && kitBreakdown.length > 0 && (
                     <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
                       <div className="h-2 w-2 flex-shrink-0 rounded-full bg-emerald-500"></div>
                       <span className="font-medium">

--- a/src/components/projects/pricing-detailed-analysis.tsx
+++ b/src/components/projects/pricing-detailed-analysis.tsx
@@ -3,25 +3,18 @@
 import { useState, useCallback } from 'react'
 import { useCanViewCosts } from '@/hooks/use-can-view-costs'
 import { motion } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
-import {
-  Euro,
-  Package,
-  TrendingUp,
-  Calculator,
-  Percent,
-  Calendar,
-  BarChart3,
-  ShoppingCart,
-  Home,
-} from 'lucide-react'
+import { Euro, Percent, Calendar, ShoppingCart, Home } from 'lucide-react'
 import type { Project } from '@/lib/types/project'
 import type { PurchaseRentalMode, ProductPeriod } from '@/lib/schemas/product'
 import { LocationPriceDisplay } from './location-price-display'
 import { ExtendedRentalHorizon } from './pricing-detailed-analysis/extended-rental-horizon'
+import { PricingOverviewCards } from './pricing-detailed-analysis/pricing-overview-cards'
+import { KitBreakdownTable } from './pricing-detailed-analysis/kit-breakdown-table'
+import { PeriodComparisonTable } from './pricing-detailed-analysis/period-comparison-table'
+import { InsightsPanel } from './pricing-detailed-analysis/insights-panel'
 import { formatPrice as formatPriceHelper, annualToMonthly } from '@/lib/utils/product-helpers'
 import {
   calculateProjectPurchaseCosts,
@@ -71,6 +64,7 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
 
   return (
     <div className="space-y-6">
+      {/* Mode & period selector */}
       <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 p-6 shadow-sm">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
@@ -134,6 +128,7 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
         )}
       </div>
 
+      {/* Overview cards */}
       <motion.div
         key={`overview-${selectedMode}-${selectedMode === 'location' ? selectedPeriod : 'achat'}`}
         initial={{ opacity: 0, y: 20 }}
@@ -141,385 +136,47 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
         transition={{ duration: 0.3 }}
         className={`grid grid-cols-1 gap-6 ${canViewCosts ? 'md:grid-cols-3' : 'md:grid-cols-1'}`}
       >
-        <motion.div
-          whileHover={{ y: -2, scale: 1.02 }}
-          className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-8 text-center shadow-sm transition-all duration-300"
-        >
-          <div className="absolute inset-0 bg-gradient-to-br from-green-500/[0.02] to-emerald-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-          <div className="relative z-10">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-green-100 to-emerald-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
-              <Euro className="h-8 w-8 text-green-600" />
-            </div>
-            {selectedMode === 'location' ? (
-              <LocationPriceDisplay
-                annualPrice={currentData.totalPrice}
-                label={`Prix total location`}
-                variant="card"
-                priceClassName="text-green-900 text-4xl"
-                secondaryClassName="text-green-600"
-                labelClassName="text-green-700 text-base font-semibold"
-                badgeClassName="border-green-500 text-green-600 bg-green-50"
-                secondaryBadgeClassName="border-green-300 text-green-500 bg-green-50"
-              />
-            ) : (
-              <>
-                <div className="mb-2 text-4xl font-bold text-green-900">
-                  {formatPriceHelper(currentData.totalPrice)}
-                </div>
-                <div className="text-base font-semibold text-green-700">Prix total (Achat)</div>
-              </>
-            )}
-          </div>
-        </motion.div>
-
-        {canViewCosts && (
-          <motion.div
-            whileHover={{ y: -2, scale: 1.02 }}
-            className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-8 text-center shadow-sm transition-all duration-300"
-          >
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/[0.02] to-indigo-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-            <div className="relative z-10">
-              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-blue-100 to-indigo-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
-                <Calculator className="h-8 w-8 text-blue-600" />
-              </div>
-              {selectedMode === 'location' ? (
-                <LocationPriceDisplay
-                  annualPrice={currentData.totalCost}
-                  label="Coût total"
-                  variant="card"
-                  priceClassName="text-blue-900 text-4xl"
-                  secondaryClassName="text-blue-600"
-                  labelClassName="text-blue-700 text-base font-semibold"
-                  badgeClassName="border-blue-500 text-blue-600 bg-blue-50"
-                  secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
-                />
-              ) : (
-                <>
-                  <div className="mb-2 text-4xl font-bold text-blue-900">
-                    {formatPriceHelper(currentData.totalCost)}
-                  </div>
-                  <div className="text-base font-semibold text-blue-700">Coût total</div>
-                </>
-              )}
-            </div>
-          </motion.div>
-        )}
-
-        {canViewCosts && (
-          <motion.div
-            whileHover={{ y: -2, scale: 1.02 }}
-            className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50 p-8 text-center shadow-sm transition-all duration-300"
-          >
-            <div className="absolute inset-0 bg-gradient-to-br from-purple-500/[0.02] to-violet-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-            <div className="relative z-10">
-              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-purple-100 to-violet-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
-                <TrendingUp className="h-8 w-8 text-purple-600" />
-              </div>
-              {selectedMode === 'location' ? (
-                <LocationPriceDisplay
-                  annualPrice={currentData.totalMargin}
-                  label="Marge totale"
-                  variant="card"
-                  priceClassName="text-purple-900 text-4xl"
-                  secondaryClassName="text-purple-600"
-                  labelClassName="text-purple-700 text-base font-semibold"
-                  badgeClassName="border-purple-500 text-purple-600 bg-purple-50"
-                  secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
-                />
-              ) : (
-                <>
-                  <div className="mb-2 text-4xl font-bold text-purple-900">
-                    {formatPriceHelper(currentData.totalMargin)}
-                  </div>
-                  <div className="text-base font-semibold text-purple-700">Marge totale</div>
-                </>
-              )}
-            </div>
-          </motion.div>
-        )}
+        <PricingOverviewCards
+          currentData={currentData}
+          selectedMode={selectedMode}
+          canViewCosts={canViewCosts}
+        />
       </motion.div>
 
+      {/* Profitability breakdown */}
       <motion.div
         key={`profitability-${selectedMode}-${selectedMode === 'location' ? selectedPeriod : 'achat'}`}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, delay: 0.1 }}
       >
-        <div className="overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 shadow-sm">
-          <div className="p-8">
-            <div className="mb-6 flex items-center justify-between">
-              <div className="flex items-center space-x-4">
-                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-100 to-orange-100 shadow-sm">
-                  <Percent className="h-7 w-7 text-amber-600" />
-                </div>
-                <div>
-                  <h3 className="text-xl font-bold text-amber-900">Rentabilité du projet</h3>
-                  <p className="text-sm font-medium text-amber-700">
-                    {selectedMode === 'achat'
-                      ? "Analyse pour l'achat de produits neufs"
-                      : `Analyse pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()}`}
-                  </p>
-                </div>
-              </div>
-              <Badge
-                variant="outline"
-                className="border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-800"
-              >
-                {selectedMode === 'achat' ? 'Achat unique' : PERIOD_LABELS[selectedPeriod]}
-              </Badge>
-            </div>
-
-            <div className={`grid grid-cols-1 gap-8 ${canViewCosts ? 'md:grid-cols-2' : ''}`}>
-              {canViewCosts && (
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
-                    <span className="text-sm font-medium text-amber-800">Marge brute</span>
-                    <span className="text-xl font-bold text-amber-900">
-                      {marginPercentage.toFixed(1)}%
-                    </span>
-                  </div>
-
-                  <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
-                    <Progress
-                      value={Math.min(marginPercentage, 100)}
-                      className="h-4 bg-amber-100"
-                    />
-                  </div>
-
-                  <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
-                    <div className="space-y-3 text-sm text-amber-700">
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium">Coût</span>
-                        <div className="text-right">
-                          <span className="font-semibold text-amber-900">
-                            {formatPriceHelper(
-                              selectedMode === 'location'
-                                ? annualToMonthly(currentData.totalCost)
-                                : currentData.totalCost,
-                            )}
-                          </span>
-                          {selectedMode === 'location' && (
-                            <span className="ml-1 text-xs text-amber-600">/mois</span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium">Marge</span>
-                        <div className="text-right">
-                          <span className="font-semibold text-amber-900">
-                            {formatPriceHelper(
-                              selectedMode === 'location'
-                                ? annualToMonthly(currentData.totalMargin)
-                                : currentData.totalMargin,
-                            )}
-                          </span>
-                          {selectedMode === 'location' && (
-                            <span className="ml-1 text-xs text-amber-600">/mois</span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="h-px bg-amber-200"></div>
-                      <div className="flex items-center justify-between">
-                        <span className="font-semibold">Prix de vente</span>
-                        <div className="text-right">
-                          <span className="font-bold text-amber-900">
-                            {formatPriceHelper(
-                              selectedMode === 'location'
-                                ? annualToMonthly(currentData.totalPrice)
-                                : currentData.totalPrice,
-                            )}
-                          </span>
-                          {selectedMode === 'location' && (
-                            <span className="ml-1 text-xs text-amber-600">/mois</span>
-                          )}
-                        </div>
-                      </div>
-                      {selectedMode === 'location' && (
-                        <div className="pt-1 text-right text-xs text-amber-500">
-                          {formatPriceHelper(currentData.totalPrice)} /an
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              <div className="space-y-4">
-                <div className="rounded-2xl border border-amber-200 bg-gradient-to-br from-white to-amber-50 p-6 text-center shadow-sm">
-                  {selectedMode === 'location' ? (
-                    <LocationPriceDisplay
-                      annualPrice={averagePricePerKit}
-                      label="Prix moyen par kit"
-                      variant="card"
-                      priceClassName="text-amber-900 text-3xl"
-                      secondaryClassName="text-amber-600"
-                      labelClassName="text-amber-700"
-                      badgeClassName="border-amber-500 text-amber-600 bg-amber-50"
-                      secondaryBadgeClassName="border-amber-300 text-amber-500 bg-amber-50"
-                    />
-                  ) : (
-                    <>
-                      <div className="mb-2 text-3xl font-bold text-amber-900">
-                        {formatPriceHelper(averagePricePerKit)}
-                      </div>
-                      <div className="text-sm font-medium text-amber-700">Prix moyen par kit</div>
-                    </>
-                  )}
-                </div>
-
-                <div className="rounded-2xl border border-amber-200 bg-gradient-to-br from-white to-amber-50 p-6 text-center shadow-sm">
-                  <div className="mb-2 text-3xl font-bold text-amber-900">
-                    {kitBreakdown.length}
-                  </div>
-                  <div className="text-sm font-medium text-amber-700">Nombre de kits</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ProfitabilityBreakdown
+          currentData={currentData}
+          marginPercentage={marginPercentage}
+          averagePricePerKit={averagePricePerKit}
+          kitCount={kitBreakdown.length}
+          selectedMode={selectedMode}
+          selectedPeriod={selectedPeriod}
+          canViewCosts={canViewCosts}
+        />
       </motion.div>
 
+      {/* Kit breakdown */}
       <motion.div
         key={`kits-detail-${selectedMode}-${selectedMode === 'location' ? selectedPeriod : 'achat'}`}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, delay: 0.2 }}
       >
-        <Card className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 shadow-sm">
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <div className="flex items-center space-x-3">
-                <div className="rounded-xl bg-gradient-to-br from-blue-100 to-indigo-100 p-2">
-                  <Package className="h-5 w-5 text-blue-600" />
-                </div>
-                <span>Détail des prix par kit</span>
-              </div>
-              <Badge variant="outline" className="bg-white text-xs">
-                {selectedMode === 'achat'
-                  ? 'Mode Achat'
-                  : `Location ${PERIOD_LABELS[selectedPeriod]}`}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {kitBreakdown.length > 0 ? (
-              <div className="space-y-4">
-                {kitBreakdown.map((kit, index) => (
-                  <motion.div
-                    key={`${kit.kitName}-${selectedMode}-${selectedMode === 'location' ? selectedPeriod : 'achat'}`}
-                    className="rounded-xl border border-gray-200 bg-white p-6 transition-all duration-200 hover:shadow-md"
-                    initial={{ opacity: 0, x: -20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ duration: 0.3, delay: index * 0.05 }}
-                  >
-                    <div className="mb-4 flex items-center justify-between">
-                      <div className="flex items-center space-x-3">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-100">
-                          <Package className="h-5 w-5 text-blue-600" />
-                        </div>
-                        <div>
-                          <h4 className="text-lg font-semibold text-gray-900">{kit.kitName}</h4>
-                          <p className="text-sm text-gray-500">Quantité: {kit.quantity}</p>
-                        </div>
-                      </div>
-                      {canViewCosts && (
-                        <Badge
-                          variant="outline"
-                          className={`text-sm font-medium ${
-                            kit.marginPercentage > 30
-                              ? 'border-green-500 bg-green-50 text-green-700'
-                              : kit.marginPercentage > 20
-                                ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
-                                : 'border-red-500 bg-red-50 text-red-700'
-                          }`}
-                        >
-                          {kit.marginPercentage.toFixed(1)}% marge
-                        </Badge>
-                      )}
-                    </div>
-
-                    <div className={`grid gap-4 ${canViewCosts ? 'grid-cols-3' : 'grid-cols-1'}`}>
-                      <div className="rounded-xl border border-green-100 bg-gradient-to-br from-green-50 to-emerald-50 p-4 text-center">
-                        {selectedMode === 'location' ? (
-                          <LocationPriceDisplay
-                            annualPrice={kit.totalPrice}
-                            label="Prix total"
-                            variant="card"
-                            priceClassName="text-green-900 text-lg"
-                            secondaryClassName="text-green-600 text-xs"
-                            labelClassName="text-green-700 text-xs"
-                            badgeClassName="border-green-500 text-green-600 bg-green-50 text-[10px] px-1 py-0"
-                            secondaryBadgeClassName="border-green-300 text-green-500 bg-green-50"
-                          />
-                        ) : (
-                          <>
-                            <div className="mb-1 text-lg font-bold text-green-900">
-                              {formatPriceHelper(kit.totalPrice)}
-                            </div>
-                            <div className="text-xs font-medium text-green-700">Prix total</div>
-                          </>
-                        )}
-                      </div>
-                      {canViewCosts && (
-                        <div className="rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50 to-indigo-50 p-4 text-center">
-                          {selectedMode === 'location' ? (
-                            <LocationPriceDisplay
-                              annualPrice={kit.totalCost}
-                              label="Coût total"
-                              variant="card"
-                              priceClassName="text-blue-900 text-lg"
-                              secondaryClassName="text-blue-600 text-xs"
-                              labelClassName="text-blue-700 text-xs"
-                              badgeClassName="border-blue-500 text-blue-600 bg-blue-50 text-[10px] px-1 py-0"
-                              secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
-                            />
-                          ) : (
-                            <>
-                              <div className="mb-1 text-lg font-bold text-blue-900">
-                                {formatPriceHelper(kit.totalCost)}
-                              </div>
-                              <div className="text-xs font-medium text-blue-700">Coût total</div>
-                            </>
-                          )}
-                        </div>
-                      )}
-                      {canViewCosts && (
-                        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-violet-50 p-4 text-center">
-                          {selectedMode === 'location' ? (
-                            <LocationPriceDisplay
-                              annualPrice={kit.totalMargin}
-                              label="Marge"
-                              variant="card"
-                              priceClassName="text-purple-900 text-lg"
-                              secondaryClassName="text-purple-600 text-xs"
-                              labelClassName="text-purple-700 text-xs"
-                              badgeClassName="border-purple-500 text-purple-600 bg-purple-50 text-[10px] px-1 py-0"
-                              secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
-                            />
-                          ) : (
-                            <>
-                              <div className="mb-1 text-lg font-bold text-purple-900">
-                                {formatPriceHelper(kit.totalMargin)}
-                              </div>
-                              <div className="text-xs font-medium text-purple-700">Marge</div>
-                            </>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  </motion.div>
-                ))}
-              </div>
-            ) : (
-              <div className="py-8 text-center text-gray-500">
-                <Package className="mx-auto mb-3 h-12 w-12 text-gray-400" />
-                <p>Aucun kit configuré pour ce projet</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <KitBreakdownTable
+          kitBreakdown={kitBreakdown}
+          selectedMode={selectedMode}
+          selectedPeriod={selectedPeriod}
+          canViewCosts={canViewCosts}
+        />
       </motion.div>
 
+      {/* Period comparison (location mode only) */}
       {selectedMode === 'location' && (
         <motion.div
           key="location-comparison"
@@ -527,122 +184,15 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, delay: 0.3 }}
         >
-          <Card className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 shadow-sm">
-            <CardHeader>
-              <CardTitle className="flex items-center justify-between">
-                <div className="flex items-center space-x-3">
-                  <div className="rounded-xl bg-gradient-to-br from-purple-100 to-indigo-100 p-2">
-                    <BarChart3 className="h-5 w-5 text-purple-600" />
-                  </div>
-                  <span>Comparaison des périodes de location</span>
-                </div>
-                <Badge variant="outline" className="bg-white text-xs">
-                  Mode Location
-                </Badge>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-gray-200">
-                      <th className="px-4 py-3 text-left font-semibold text-gray-700">Période</th>
-                      <th className="px-4 py-3 text-right font-semibold text-gray-700">
-                        Prix /mois
-                      </th>
-                      {canViewCosts && (
-                        <th className="px-4 py-3 text-right font-semibold text-gray-700">
-                          Coût /mois
-                        </th>
-                      )}
-                      {canViewCosts && (
-                        <th className="px-4 py-3 text-right font-semibold text-gray-700">
-                          Marge /mois
-                        </th>
-                      )}
-                      {canViewCosts && (
-                        <th className="px-4 py-3 text-right font-semibold text-gray-700">
-                          Marge %
-                        </th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {(['1an', '2ans', '3ans'] as ProductPeriod[]).map((period) => {
-                      const prices = calculateProjectRentalCosts(project, period)
-                      const marginPercent =
-                        prices.totalPrice > 0 ? (prices.totalMargin / prices.totalPrice) * 100 : 0
-
-                      return (
-                        <tr
-                          key={period}
-                          className={`border-b border-gray-100 transition-colors hover:bg-gray-50 ${
-                            selectedPeriod === period ? 'bg-[#30C1BD]/5' : ''
-                          }`}
-                        >
-                          <td className="px-4 py-4">
-                            <div className="flex items-center space-x-2">
-                              {selectedPeriod === period && (
-                                <div className="h-2 w-2 rounded-full bg-[#30C1BD]"></div>
-                              )}
-                              <span className="font-medium">{PERIOD_LABELS[period]}</span>
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 text-right">
-                            <div className="font-semibold">
-                              {formatPriceHelper(annualToMonthly(prices.totalPrice))}
-                            </div>
-                            <div className="text-xs text-gray-400">
-                              {formatPriceHelper(prices.totalPrice)} /an
-                            </div>
-                          </td>
-                          {canViewCosts && (
-                            <td className="px-4 py-4 text-right">
-                              <div className="text-gray-600">
-                                {formatPriceHelper(annualToMonthly(prices.totalCost))}
-                              </div>
-                              <div className="text-xs text-gray-400">
-                                {formatPriceHelper(prices.totalCost)} /an
-                              </div>
-                            </td>
-                          )}
-                          {canViewCosts && (
-                            <td className="px-4 py-4 text-right">
-                              <div className="font-medium text-green-600">
-                                {formatPriceHelper(annualToMonthly(prices.totalMargin))}
-                              </div>
-                              <div className="text-xs text-gray-400">
-                                {formatPriceHelper(prices.totalMargin)} /an
-                              </div>
-                            </td>
-                          )}
-                          {canViewCosts && (
-                            <td className="px-4 py-4 text-right">
-                              <Badge
-                                variant="outline"
-                                className={`font-medium ${
-                                  marginPercent > 30
-                                    ? 'border-green-500 bg-green-50 text-green-700'
-                                    : marginPercent > 20
-                                      ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
-                                      : 'border-red-500 bg-red-50 text-red-700'
-                                }`}
-                              >
-                                {marginPercent.toFixed(1)}%
-                              </Badge>
-                            </td>
-                          )}
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </CardContent>
-          </Card>
+          <PeriodComparisonTable
+            project={project}
+            selectedPeriod={selectedPeriod}
+            canViewCosts={canViewCosts}
+          />
         </motion.div>
       )}
 
+      {/* Extended rental horizon (location mode only) */}
       {selectedMode === 'location' && (
         <ExtendedRentalHorizon
           project={project}
@@ -651,93 +201,173 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
         />
       )}
 
+      {/* Insights */}
       <motion.div
         key={`insights-${selectedMode}-${selectedMode === 'location' ? selectedPeriod : 'achat'}`}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, delay: 0.4 }}
       >
-        <Card className="rounded-2xl border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 shadow-sm">
-          <CardContent className="p-8">
-            <div className="flex items-start space-x-4">
-              <div className="rounded-xl bg-gradient-to-br from-indigo-100 to-purple-100 p-2">
-                <BarChart3 className="h-6 w-6 text-indigo-600" />
+        <InsightsPanel
+          currentData={currentData}
+          kitBreakdown={kitBreakdown}
+          marginPercentage={marginPercentage}
+          averagePricePerKit={averagePricePerKit}
+          selectedMode={selectedMode}
+          selectedPeriod={selectedPeriod}
+          canViewCosts={canViewCosts}
+        />
+      </motion.div>
+    </div>
+  )
+}
+
+interface ProfitabilityBreakdownProps {
+  currentData: { totalPrice: number; totalCost: number; totalMargin: number }
+  marginPercentage: number
+  averagePricePerKit: number
+  kitCount: number
+  selectedMode: PurchaseRentalMode
+  selectedPeriod: ProductPeriod
+  canViewCosts: boolean
+}
+
+function ProfitabilityBreakdown({
+  currentData,
+  marginPercentage,
+  averagePricePerKit,
+  kitCount,
+  selectedMode,
+  selectedPeriod,
+  canViewCosts,
+}: ProfitabilityBreakdownProps) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 shadow-sm">
+      <div className="p-8">
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-100 to-orange-100 shadow-sm">
+              <Percent className="h-7 w-7 text-amber-600" />
+            </div>
+            <div>
+              <h3 className="text-xl font-bold text-amber-900">Rentabilité du projet</h3>
+              <p className="text-sm font-medium text-amber-700">
+                {selectedMode === 'achat'
+                  ? "Analyse pour l'achat de produits neufs"
+                  : `Analyse pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()}`}
+              </p>
+            </div>
+          </div>
+          <Badge
+            variant="outline"
+            className="border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-800"
+          >
+            {selectedMode === 'achat' ? 'Achat unique' : PERIOD_LABELS[selectedPeriod]}
+          </Badge>
+        </div>
+
+        <div className={`grid grid-cols-1 gap-8 ${canViewCosts ? 'md:grid-cols-2' : ''}`}>
+          {canViewCosts && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
+                <span className="text-sm font-medium text-amber-800">Marge brute</span>
+                <span className="text-xl font-bold text-amber-900">
+                  {marginPercentage.toFixed(1)}%
+                </span>
               </div>
-              <div className="flex-1">
-                <h3 className="mb-4 text-xl font-bold text-indigo-900">
-                  Analyse et recommandations
-                </h3>
-                <div className="space-y-3 text-sm text-indigo-800">
-                  {canViewCosts &&
-                    (marginPercentage > 30 ? (
-                      <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                        <div className="h-2 w-2 flex-shrink-0 rounded-full bg-green-500"></div>
-                        <span className="font-medium">
-                          Excellente rentabilité ! Votre marge de {marginPercentage.toFixed(1)}% est
-                          très bonne.
-                        </span>
-                      </div>
-                    ) : marginPercentage > 20 ? (
-                      <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                        <div className="h-2 w-2 flex-shrink-0 rounded-full bg-yellow-500"></div>
-                        <span className="font-medium">
-                          Rentabilité correcte. Considérez optimiser les coûts pour améliorer la
-                          marge.
-                        </span>
-                      </div>
-                    ) : (
-                      <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                        <div className="h-2 w-2 flex-shrink-0 rounded-full bg-red-500"></div>
-                        <span className="font-medium">
-                          Marge faible. Analysez les coûts et considérez ajuster les prix.
-                        </span>
-                      </div>
-                    ))}
 
-                  <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                    <div className="h-2 w-2 flex-shrink-0 rounded-full bg-blue-500"></div>
-                    <span className="font-medium">
-                      Prix moyen par kit : {formatPriceHelper(averagePricePerKit)}
-                    </span>
-                  </div>
+              <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
+                <Progress value={Math.min(marginPercentage, 100)} className="h-4 bg-amber-100" />
+              </div>
 
-                  {canViewCosts && (
-                    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                      <div className="h-2 w-2 flex-shrink-0 rounded-full bg-purple-500"></div>
-                      <span className="font-medium">
-                        {selectedMode === 'achat'
-                          ? `Coût total pour l'achat : ${formatPriceHelper(currentData.totalCost)}`
-                          : `Coût total pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()} : ${formatPriceHelper(currentData.totalCost)}`}
+              <div className="rounded-xl border border-amber-200 bg-white p-4 shadow-sm">
+                <div className="space-y-3 text-sm text-amber-700">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">Coût</span>
+                    <div className="text-right">
+                      <span className="font-semibold text-amber-900">
+                        {formatPriceHelper(
+                          selectedMode === 'location'
+                            ? annualToMonthly(currentData.totalCost)
+                            : currentData.totalCost,
+                        )}
                       </span>
+                      {selectedMode === 'location' && (
+                        <span className="ml-1 text-xs text-amber-600">/mois</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">Marge</span>
+                    <div className="text-right">
+                      <span className="font-semibold text-amber-900">
+                        {formatPriceHelper(
+                          selectedMode === 'location'
+                            ? annualToMonthly(currentData.totalMargin)
+                            : currentData.totalMargin,
+                        )}
+                      </span>
+                      {selectedMode === 'location' && (
+                        <span className="ml-1 text-xs text-amber-600">/mois</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="h-px bg-amber-200"></div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold">Prix de vente</span>
+                    <div className="text-right">
+                      <span className="font-bold text-amber-900">
+                        {formatPriceHelper(
+                          selectedMode === 'location'
+                            ? annualToMonthly(currentData.totalPrice)
+                            : currentData.totalPrice,
+                        )}
+                      </span>
+                      {selectedMode === 'location' && (
+                        <span className="ml-1 text-xs text-amber-600">/mois</span>
+                      )}
+                    </div>
+                  </div>
+                  {selectedMode === 'location' && (
+                    <div className="pt-1 text-right text-xs text-amber-500">
+                      {formatPriceHelper(currentData.totalPrice)} /an
                     </div>
                   )}
-
-                  {canViewCosts && kitBreakdown.length > 0 && (
-                    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                      <div className="h-2 w-2 flex-shrink-0 rounded-full bg-emerald-500"></div>
-                      <span className="font-medium">
-                        Kit le plus rentable :{' '}
-                        {kitBreakdown.reduce((max, kit) =>
-                          kit.marginPercentage > max.marginPercentage ? kit : max,
-                        )?.kitName || 'N/A'}
-                      </span>
-                    </div>
-                  )}
-
-                  <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
-                    <div className="h-2 w-2 flex-shrink-0 rounded-full bg-amber-500"></div>
-                    <span className="font-medium">
-                      {selectedMode === 'achat'
-                        ? 'Achat de produits neufs avec impact environnemental complet'
-                        : "Location d'équipements existants avec impact environnemental réduit"}
-                    </span>
-                  </div>
                 </div>
               </div>
             </div>
-          </CardContent>
-        </Card>
-      </motion.div>
+          )}
+
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-amber-200 bg-gradient-to-br from-white to-amber-50 p-6 text-center shadow-sm">
+              {selectedMode === 'location' ? (
+                <LocationPriceDisplay
+                  annualPrice={averagePricePerKit}
+                  label="Prix moyen par kit"
+                  variant="card"
+                  priceClassName="text-amber-900 text-3xl"
+                  secondaryClassName="text-amber-600"
+                  labelClassName="text-amber-700"
+                  badgeClassName="border-amber-500 text-amber-600 bg-amber-50"
+                  secondaryBadgeClassName="border-amber-300 text-amber-500 bg-amber-50"
+                />
+              ) : (
+                <>
+                  <div className="mb-2 text-3xl font-bold text-amber-900">
+                    {formatPriceHelper(averagePricePerKit)}
+                  </div>
+                  <div className="text-sm font-medium text-amber-700">Prix moyen par kit</div>
+                </>
+              )}
+            </div>
+
+            <div className="rounded-2xl border border-amber-200 bg-gradient-to-br from-white to-amber-50 p-6 text-center shadow-sm">
+              <div className="mb-2 text-3xl font-bold text-amber-900">{kitCount}</div>
+              <div className="text-sm font-medium text-amber-700">Nombre de kits</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/projects/pricing-detailed-analysis/insights-panel.tsx
+++ b/src/components/projects/pricing-detailed-analysis/insights-panel.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { BarChart3 } from 'lucide-react'
+import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
+import type { PurchaseRentalMode, ProductPeriod } from '@/lib/schemas/product'
+import type { ProjectCostBreakdown, KitBreakdownItem } from '@/lib/utils/project/calculations'
+
+const PERIOD_LABELS: Record<ProductPeriod, string> = {
+  '1an': '1 an',
+  '2ans': '2 ans',
+  '3ans': '3 ans',
+}
+
+interface InsightsPanelProps {
+  currentData: ProjectCostBreakdown
+  kitBreakdown: readonly KitBreakdownItem[]
+  marginPercentage: number
+  averagePricePerKit: number
+  selectedMode: PurchaseRentalMode
+  selectedPeriod: ProductPeriod
+  canViewCosts: boolean
+}
+
+/**
+ * Analysis and recommendations panel showing profitability insights and pricing tips.
+ * Margin-related insights are only visible to admin/dev users.
+ * @param props - Calculated pricing data, mode/period selection, and cost visibility flag
+ * @returns Card with contextual insights and recommendations
+ */
+export function InsightsPanel({
+  currentData,
+  kitBreakdown,
+  marginPercentage,
+  averagePricePerKit,
+  selectedMode,
+  selectedPeriod,
+  canViewCosts,
+}: InsightsPanelProps) {
+  return (
+    <Card className="rounded-2xl border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 shadow-sm">
+      <CardContent className="p-8">
+        <div className="flex items-start space-x-4">
+          <div className="rounded-xl bg-gradient-to-br from-indigo-100 to-purple-100 p-2">
+            <BarChart3 className="h-6 w-6 text-indigo-600" />
+          </div>
+          <div className="flex-1">
+            <h3 className="mb-4 text-xl font-bold text-indigo-900">Analyse et recommandations</h3>
+            <div className="space-y-3 text-sm text-indigo-800">
+              {canViewCosts &&
+                (marginPercentage > 30 ? (
+                  <InsightRow color="green">
+                    Excellente rentabilité ! Votre marge de {marginPercentage.toFixed(1)}% est très
+                    bonne.
+                  </InsightRow>
+                ) : marginPercentage > 20 ? (
+                  <InsightRow color="yellow">
+                    Rentabilité correcte. Considérez optimiser les coûts pour améliorer la marge.
+                  </InsightRow>
+                ) : (
+                  <InsightRow color="red">
+                    Marge faible. Analysez les coûts et considérez ajuster les prix.
+                  </InsightRow>
+                ))}
+
+              <InsightRow color="blue">
+                Prix moyen par kit : {formatPriceHelper(averagePricePerKit)}
+              </InsightRow>
+
+              {canViewCosts && (
+                <InsightRow color="purple">
+                  {selectedMode === 'achat'
+                    ? `Coût total pour l'achat : ${formatPriceHelper(currentData.totalCost)}`
+                    : `Coût total pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()} : ${formatPriceHelper(currentData.totalCost)}`}
+                </InsightRow>
+              )}
+
+              {canViewCosts && kitBreakdown.length > 0 && (
+                <InsightRow color="emerald">
+                  Kit le plus rentable :{' '}
+                  {kitBreakdown.reduce((max, kit) =>
+                    kit.marginPercentage > max.marginPercentage ? kit : max,
+                  )?.kitName || 'N/A'}
+                </InsightRow>
+              )}
+
+              <InsightRow color="amber">
+                {selectedMode === 'achat'
+                  ? 'Achat de produits neufs avec impact environnemental complet'
+                  : "Location d'équipements existants avec impact environnemental réduit"}
+              </InsightRow>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+const DOT_COLORS = {
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  red: 'bg-red-500',
+  blue: 'bg-blue-500',
+  purple: 'bg-purple-500',
+  emerald: 'bg-emerald-500',
+  amber: 'bg-amber-500',
+} as const
+
+type DotColor = keyof typeof DOT_COLORS
+
+function InsightRow({ color, children }: { color: DotColor; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center space-x-3 rounded-xl border border-white/50 bg-white/60 p-3">
+      <div className={`h-2 w-2 flex-shrink-0 rounded-full ${DOT_COLORS[color]}`}></div>
+      <span className="font-medium">{children}</span>
+    </div>
+  )
+}

--- a/src/components/projects/pricing-detailed-analysis/kit-breakdown-table.tsx
+++ b/src/components/projects/pricing-detailed-analysis/kit-breakdown-table.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Package } from 'lucide-react'
+import { LocationPriceDisplay } from '../location-price-display'
+import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
+import type { PurchaseRentalMode, ProductPeriod } from '@/lib/schemas/product'
+import type { KitBreakdownItem } from '@/lib/utils/project/calculations'
+
+const PERIOD_LABELS: Record<ProductPeriod, string> = {
+  '1an': '1 an',
+  '2ans': '2 ans',
+  '3ans': '3 ans',
+}
+
+interface KitBreakdownTableProps {
+  kitBreakdown: readonly KitBreakdownItem[]
+  selectedMode: PurchaseRentalMode
+  selectedPeriod: ProductPeriod
+  canViewCosts: boolean
+}
+
+/**
+ * Detailed per-kit pricing breakdown showing price, cost, and margin for each kit.
+ * Cost and margin columns are only visible to admin/dev users.
+ * @param props - Kit breakdown data, selected mode/period, and cost visibility flag
+ * @returns Card with kit-by-kit pricing details
+ */
+export function KitBreakdownTable({
+  kitBreakdown,
+  selectedMode,
+  selectedPeriod,
+  canViewCosts,
+}: KitBreakdownTableProps) {
+  return (
+    <Card className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 shadow-sm">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="rounded-xl bg-gradient-to-br from-blue-100 to-indigo-100 p-2">
+              <Package className="h-5 w-5 text-blue-600" />
+            </div>
+            <span>Détail des prix par kit</span>
+          </div>
+          <Badge variant="outline" className="bg-white text-xs">
+            {selectedMode === 'achat' ? 'Mode Achat' : `Location ${PERIOD_LABELS[selectedPeriod]}`}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {kitBreakdown.length > 0 ? (
+          <div className="space-y-4">
+            {kitBreakdown.map((kit, index) => (
+              <motion.div
+                key={`${kit.kitName}-${selectedMode}-${selectedMode === 'location' ? selectedPeriod : 'achat'}`}
+                className="rounded-xl border border-gray-200 bg-white p-6 transition-all duration-200 hover:shadow-md"
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3, delay: index * 0.05 }}
+              >
+                <div className="mb-4 flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-100">
+                      <Package className="h-5 w-5 text-blue-600" />
+                    </div>
+                    <div>
+                      <h4 className="text-lg font-semibold text-gray-900">{kit.kitName}</h4>
+                      <p className="text-sm text-gray-500">Quantité: {kit.quantity}</p>
+                    </div>
+                  </div>
+                  {canViewCosts && (
+                    <Badge
+                      variant="outline"
+                      className={`text-sm font-medium ${
+                        kit.marginPercentage > 30
+                          ? 'border-green-500 bg-green-50 text-green-700'
+                          : kit.marginPercentage > 20
+                            ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
+                            : 'border-red-500 bg-red-50 text-red-700'
+                      }`}
+                    >
+                      {kit.marginPercentage.toFixed(1)}% marge
+                    </Badge>
+                  )}
+                </div>
+
+                <div className={`grid gap-4 ${canViewCosts ? 'grid-cols-3' : 'grid-cols-1'}`}>
+                  <div className="rounded-xl border border-green-100 bg-gradient-to-br from-green-50 to-emerald-50 p-4 text-center">
+                    {selectedMode === 'location' ? (
+                      <LocationPriceDisplay
+                        annualPrice={kit.totalPrice}
+                        label="Prix total"
+                        variant="card"
+                        priceClassName="text-green-900 text-lg"
+                        secondaryClassName="text-green-600 text-xs"
+                        labelClassName="text-green-700 text-xs"
+                        badgeClassName="border-green-500 text-green-600 bg-green-50 text-[10px] px-1 py-0"
+                        secondaryBadgeClassName="border-green-300 text-green-500 bg-green-50"
+                      />
+                    ) : (
+                      <>
+                        <div className="mb-1 text-lg font-bold text-green-900">
+                          {formatPriceHelper(kit.totalPrice)}
+                        </div>
+                        <div className="text-xs font-medium text-green-700">Prix total</div>
+                      </>
+                    )}
+                  </div>
+                  {canViewCosts && (
+                    <div className="rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50 to-indigo-50 p-4 text-center">
+                      {selectedMode === 'location' ? (
+                        <LocationPriceDisplay
+                          annualPrice={kit.totalCost}
+                          label="Coût total"
+                          variant="card"
+                          priceClassName="text-blue-900 text-lg"
+                          secondaryClassName="text-blue-600 text-xs"
+                          labelClassName="text-blue-700 text-xs"
+                          badgeClassName="border-blue-500 text-blue-600 bg-blue-50 text-[10px] px-1 py-0"
+                          secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
+                        />
+                      ) : (
+                        <>
+                          <div className="mb-1 text-lg font-bold text-blue-900">
+                            {formatPriceHelper(kit.totalCost)}
+                          </div>
+                          <div className="text-xs font-medium text-blue-700">Coût total</div>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  {canViewCosts && (
+                    <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-violet-50 p-4 text-center">
+                      {selectedMode === 'location' ? (
+                        <LocationPriceDisplay
+                          annualPrice={kit.totalMargin}
+                          label="Marge"
+                          variant="card"
+                          priceClassName="text-purple-900 text-lg"
+                          secondaryClassName="text-purple-600 text-xs"
+                          labelClassName="text-purple-700 text-xs"
+                          badgeClassName="border-purple-500 text-purple-600 bg-purple-50 text-[10px] px-1 py-0"
+                          secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
+                        />
+                      ) : (
+                        <>
+                          <div className="mb-1 text-lg font-bold text-purple-900">
+                            {formatPriceHelper(kit.totalMargin)}
+                          </div>
+                          <div className="text-xs font-medium text-purple-700">Marge</div>
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        ) : (
+          <div className="py-8 text-center text-gray-500">
+            <Package className="mx-auto mb-3 h-12 w-12 text-gray-400" />
+            <p>Aucun kit configuré pour ce projet</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/projects/pricing-detailed-analysis/period-comparison-table.tsx
+++ b/src/components/projects/pricing-detailed-analysis/period-comparison-table.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { BarChart3 } from 'lucide-react'
+import { formatPrice as formatPriceHelper, annualToMonthly } from '@/lib/utils/product-helpers'
+import { calculateProjectRentalCosts } from '@/lib/utils/project/calculations'
+import type { Project } from '@/lib/types/project'
+import type { ProductPeriod } from '@/lib/schemas/product'
+
+const PERIOD_LABELS: Record<ProductPeriod, string> = {
+  '1an': '1 an',
+  '2ans': '2 ans',
+  '3ans': '3 ans',
+}
+
+const PERIODS: readonly ProductPeriod[] = ['1an', '2ans', '3ans'] as const
+
+interface PeriodComparisonTableProps {
+  project: Project
+  selectedPeriod: ProductPeriod
+  canViewCosts: boolean
+}
+
+/**
+ * Comparison table showing pricing across all rental periods (1, 2, 3 years).
+ * Memoizes rental cost calculations to avoid redundant computation on re-renders.
+ * Cost/margin columns are only visible to admin/dev users.
+ * @param props - Project data, currently selected period, and cost visibility flag
+ * @returns Card with period comparison table
+ */
+export function PeriodComparisonTable({
+  project,
+  selectedPeriod,
+  canViewCosts,
+}: PeriodComparisonTableProps) {
+  const periodData = useMemo(
+    () =>
+      PERIODS.map((period) => {
+        const prices = calculateProjectRentalCosts(project, period)
+        const marginPercent =
+          prices.totalPrice > 0 ? (prices.totalMargin / prices.totalPrice) * 100 : 0
+        return { period, prices, marginPercent }
+      }),
+    [project],
+  )
+
+  return (
+    <Card className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 shadow-sm">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="rounded-xl bg-gradient-to-br from-purple-100 to-indigo-100 p-2">
+              <BarChart3 className="h-5 w-5 text-purple-600" />
+            </div>
+            <span>Comparaison des périodes de location</span>
+          </div>
+          <Badge variant="outline" className="bg-white text-xs">
+            Mode Location
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="px-4 py-3 text-left font-semibold text-gray-700">Période</th>
+                <th className="px-4 py-3 text-right font-semibold text-gray-700">Prix /mois</th>
+                {canViewCosts && (
+                  <>
+                    <th className="px-4 py-3 text-right font-semibold text-gray-700">Coût /mois</th>
+                    <th className="px-4 py-3 text-right font-semibold text-gray-700">
+                      Marge /mois
+                    </th>
+                    <th className="px-4 py-3 text-right font-semibold text-gray-700">Marge %</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {periodData.map(({ period, prices, marginPercent }) => (
+                <tr
+                  key={period}
+                  className={`border-b border-gray-100 transition-colors hover:bg-gray-50 ${
+                    selectedPeriod === period ? 'bg-[#30C1BD]/5' : ''
+                  }`}
+                >
+                  <td className="px-4 py-4">
+                    <div className="flex items-center space-x-2">
+                      {selectedPeriod === period && (
+                        <div className="h-2 w-2 rounded-full bg-[#30C1BD]"></div>
+                      )}
+                      <span className="font-medium">{PERIOD_LABELS[period]}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-4 text-right">
+                    <div className="font-semibold">
+                      {formatPriceHelper(annualToMonthly(prices.totalPrice))}
+                    </div>
+                    <div className="text-xs text-gray-400">
+                      {formatPriceHelper(prices.totalPrice)} /an
+                    </div>
+                  </td>
+                  {canViewCosts && (
+                    <>
+                      <td className="px-4 py-4 text-right">
+                        <div className="text-gray-600">
+                          {formatPriceHelper(annualToMonthly(prices.totalCost))}
+                        </div>
+                        <div className="text-xs text-gray-400">
+                          {formatPriceHelper(prices.totalCost)} /an
+                        </div>
+                      </td>
+                      <td className="px-4 py-4 text-right">
+                        <div className="font-medium text-green-600">
+                          {formatPriceHelper(annualToMonthly(prices.totalMargin))}
+                        </div>
+                        <div className="text-xs text-gray-400">
+                          {formatPriceHelper(prices.totalMargin)} /an
+                        </div>
+                      </td>
+                      <td className="px-4 py-4 text-right">
+                        <Badge
+                          variant="outline"
+                          className={`font-medium ${
+                            marginPercent > 30
+                              ? 'border-green-500 bg-green-50 text-green-700'
+                              : marginPercent > 20
+                                ? 'border-yellow-500 bg-yellow-50 text-yellow-700'
+                                : 'border-red-500 bg-red-50 text-red-700'
+                          }`}
+                        >
+                          {marginPercent.toFixed(1)}%
+                        </Badge>
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/projects/pricing-detailed-analysis/pricing-overview-cards.tsx
+++ b/src/components/projects/pricing-detailed-analysis/pricing-overview-cards.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Euro, Calculator, TrendingUp } from 'lucide-react'
+import { LocationPriceDisplay } from '../location-price-display'
+import { formatPrice as formatPriceHelper } from '@/lib/utils/product-helpers'
+import type { PurchaseRentalMode } from '@/lib/schemas/product'
+import type { ProjectCostBreakdown } from '@/lib/utils/project/calculations'
+
+interface PricingOverviewCardsProps {
+  currentData: ProjectCostBreakdown
+  selectedMode: PurchaseRentalMode
+  canViewCosts: boolean
+}
+
+/**
+ * Overview cards showing total price, cost, and margin for the selected pricing mode.
+ * Cost and margin cards are only visible to admin/dev users.
+ * @param props - Current cost breakdown, selected mode, and cost visibility flag
+ * @returns Grid of overview metric cards
+ */
+export function PricingOverviewCards({
+  currentData,
+  selectedMode,
+  canViewCosts,
+}: PricingOverviewCardsProps) {
+  return (
+    <>
+      <motion.div
+        whileHover={{ y: -2, scale: 1.02 }}
+        className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-8 text-center shadow-sm transition-all duration-300"
+      >
+        <div className="absolute inset-0 bg-gradient-to-br from-green-500/[0.02] to-emerald-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+        <div className="relative z-10">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-green-100 to-emerald-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
+            <Euro className="h-8 w-8 text-green-600" />
+          </div>
+          {selectedMode === 'location' ? (
+            <LocationPriceDisplay
+              annualPrice={currentData.totalPrice}
+              label={`Prix total location`}
+              variant="card"
+              priceClassName="text-green-900 text-4xl"
+              secondaryClassName="text-green-600"
+              labelClassName="text-green-700 text-base font-semibold"
+              badgeClassName="border-green-500 text-green-600 bg-green-50"
+              secondaryBadgeClassName="border-green-300 text-green-500 bg-green-50"
+            />
+          ) : (
+            <>
+              <div className="mb-2 text-4xl font-bold text-green-900">
+                {formatPriceHelper(currentData.totalPrice)}
+              </div>
+              <div className="text-base font-semibold text-green-700">Prix total (Achat)</div>
+            </>
+          )}
+        </div>
+      </motion.div>
+
+      {canViewCosts && (
+        <motion.div
+          whileHover={{ y: -2, scale: 1.02 }}
+          className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-8 text-center shadow-sm transition-all duration-300"
+        >
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-500/[0.02] to-indigo-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+          <div className="relative z-10">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-blue-100 to-indigo-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
+              <Calculator className="h-8 w-8 text-blue-600" />
+            </div>
+            {selectedMode === 'location' ? (
+              <LocationPriceDisplay
+                annualPrice={currentData.totalCost}
+                label="Coût total"
+                variant="card"
+                priceClassName="text-blue-900 text-4xl"
+                secondaryClassName="text-blue-600"
+                labelClassName="text-blue-700 text-base font-semibold"
+                badgeClassName="border-blue-500 text-blue-600 bg-blue-50"
+                secondaryBadgeClassName="border-blue-300 text-blue-500 bg-blue-50"
+              />
+            ) : (
+              <>
+                <div className="mb-2 text-4xl font-bold text-blue-900">
+                  {formatPriceHelper(currentData.totalCost)}
+                </div>
+                <div className="text-base font-semibold text-blue-700">Coût total</div>
+              </>
+            )}
+          </div>
+        </motion.div>
+      )}
+
+      {canViewCosts && (
+        <motion.div
+          whileHover={{ y: -2, scale: 1.02 }}
+          className="hover:shadow-elegant group relative overflow-hidden rounded-2xl border border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50 p-8 text-center shadow-sm transition-all duration-300"
+        >
+          <div className="absolute inset-0 bg-gradient-to-br from-purple-500/[0.02] to-violet-500/[0.02] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+          <div className="relative z-10">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-purple-100 to-violet-100 shadow-sm transition-transform duration-300 group-hover:scale-110">
+              <TrendingUp className="h-8 w-8 text-purple-600" />
+            </div>
+            {selectedMode === 'location' ? (
+              <LocationPriceDisplay
+                annualPrice={currentData.totalMargin}
+                label="Marge totale"
+                variant="card"
+                priceClassName="text-purple-900 text-4xl"
+                secondaryClassName="text-purple-600"
+                labelClassName="text-purple-700 text-base font-semibold"
+                badgeClassName="border-purple-500 text-purple-600 bg-purple-50"
+                secondaryBadgeClassName="border-purple-300 text-purple-500 bg-purple-50"
+              />
+            ) : (
+              <>
+                <div className="mb-2 text-4xl font-bold text-purple-900">
+                  {formatPriceHelper(currentData.totalMargin)}
+                </div>
+                <div className="text-base font-semibold text-purple-700">Marge totale</div>
+              </>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </>
+  )
+}

--- a/src/hooks/use-can-view-costs.ts
+++ b/src/hooks/use-can-view-costs.ts
@@ -1,0 +1,12 @@
+'use client'
+
+import { useRole } from './use-role'
+
+/**
+ * Returns whether the current user can view internal cost and margin data.
+ * Only ADMIN and DEV roles have access to prixAchat, prixUnitaire, and margeCoefficient fields.
+ */
+export function useCanViewCosts(): boolean {
+  const { isDevOrAdmin } = useRole()
+  return isDevOrAdmin
+}

--- a/src/lib/utils/strip-cost-fields.test.ts
+++ b/src/lib/utils/strip-cost-fields.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest'
+import { stripCostFieldsFromProduct, stripCostFieldsDeep } from './strip-cost-fields'
+
+describe('stripCostFieldsFromProduct', () => {
+  it('removes prixAchat* fields', () => {
+    const product = {
+      id: '1',
+      nom: 'Product A',
+      prixAchatAchat: 100,
+      prixAchatLocation1An: 50,
+      prixAchatLocation2Ans: 40,
+      prixAchatLocation3Ans: 30,
+    }
+
+    const result = stripCostFieldsFromProduct(product)
+
+    expect(result).toEqual({ id: '1', nom: 'Product A' })
+    expect('prixAchatAchat' in result).toBe(false)
+    expect('prixAchatLocation1An' in result).toBe(false)
+  })
+
+  it('removes prixUnitaire* fields', () => {
+    const product = {
+      id: '1',
+      prixUnitaireAchat: 200,
+      prixUnitaireLocation1An: 80,
+      reference: 'REF-001',
+    }
+
+    const result = stripCostFieldsFromProduct(product)
+
+    expect(result).toEqual({ id: '1', reference: 'REF-001' })
+  })
+
+  it('removes margeCoefficient* fields', () => {
+    const product = {
+      id: '1',
+      margeCoefficientAchat: 1.5,
+      margeCoefficientLocation: 1.3,
+      nom: 'Product B',
+    }
+
+    const result = stripCostFieldsFromProduct(product)
+
+    expect(result).toEqual({ id: '1', nom: 'Product B' })
+  })
+
+  it('preserves non-cost fields', () => {
+    const product = {
+      id: '1',
+      nom: 'Product C',
+      reference: 'REF-002',
+      prixVenteAchat: 300,
+      surface: 10,
+    }
+
+    const result = stripCostFieldsFromProduct(product)
+
+    expect(result).toEqual({
+      id: '1',
+      nom: 'Product C',
+      reference: 'REF-002',
+      prixVenteAchat: 300,
+      surface: 10,
+    })
+  })
+
+  it('returns empty object for product with only cost fields', () => {
+    const product = {
+      prixAchatAchat: 100,
+      prixUnitaireAchat: 200,
+      margeCoefficientAchat: 1.5,
+    }
+
+    const result = stripCostFieldsFromProduct(product)
+
+    expect(result).toEqual({})
+  })
+
+  it('does not mutate the original object', () => {
+    const product = { id: '1', prixAchatAchat: 100 }
+    const original = { ...product }
+
+    stripCostFieldsFromProduct(product)
+
+    expect(product).toEqual(original)
+  })
+})
+
+describe('stripCostFieldsDeep', () => {
+  it('returns null as-is', () => {
+    expect(stripCostFieldsDeep(null)).toBeNull()
+  })
+
+  it('returns undefined as-is', () => {
+    expect(stripCostFieldsDeep(undefined)).toBeUndefined()
+  })
+
+  it('returns primitives as-is', () => {
+    expect(stripCostFieldsDeep('hello')).toBe('hello')
+    expect(stripCostFieldsDeep(42)).toBe(42)
+    expect(stripCostFieldsDeep(true)).toBe(true)
+  })
+
+  it('strips cost fields from a flat product object', () => {
+    const product = {
+      id: '1',
+      nom: 'Product',
+      prixAchatAchat: 100,
+      prixUnitaireAchat: 200,
+      margeCoefficientAchat: 1.5,
+    }
+
+    const result = stripCostFieldsDeep(product)
+
+    expect(result).toEqual({ id: '1', nom: 'Product' })
+  })
+
+  it('strips cost fields from nested product key', () => {
+    const kitProduct = {
+      id: 'kp1',
+      quantite: 2,
+      product: {
+        id: 'p1',
+        nom: 'Product A',
+        prixAchatAchat: 100,
+        prixVenteAchat: 300,
+      },
+    }
+
+    const result = stripCostFieldsDeep(kitProduct)
+
+    expect(result.product).toEqual({
+      id: 'p1',
+      nom: 'Product A',
+      prixVenteAchat: 300,
+    })
+    expect('prixAchatAchat' in (result.product as Record<string, unknown>)).toBe(false)
+  })
+
+  it('strips cost fields from kitProducts array', () => {
+    const kit = {
+      id: 'k1',
+      nom: 'Kit A',
+      kitProducts: [
+        {
+          id: 'kp1',
+          product: {
+            id: 'p1',
+            prixAchatAchat: 100,
+            prixVenteAchat: 300,
+          },
+        },
+        {
+          id: 'kp2',
+          product: {
+            id: 'p2',
+            prixAchatAchat: 50,
+            prixVenteAchat: 150,
+          },
+        },
+      ],
+    }
+
+    const result = stripCostFieldsDeep(kit) as typeof kit
+
+    expect(result.kitProducts[0]?.product).toEqual({ id: 'p1', prixVenteAchat: 300 })
+    expect(result.kitProducts[1]?.product).toEqual({ id: 'p2', prixVenteAchat: 150 })
+  })
+
+  it('strips cost fields from projectKits -> kit -> kitProducts -> product', () => {
+    const project = {
+      id: 'proj1',
+      nom: 'Project',
+      projectKits: [
+        {
+          id: 'pk1',
+          kit: {
+            id: 'k1',
+            kitProducts: [
+              {
+                id: 'kp1',
+                product: {
+                  id: 'p1',
+                  nom: 'Product',
+                  prixAchatAchat: 100,
+                  prixUnitaireAchat: 200,
+                  margeCoefficientAchat: 1.5,
+                  prixVenteAchat: 300,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }
+
+    const result = stripCostFieldsDeep(project) as typeof project
+
+    const product = result.projectKits[0]?.kit.kitProducts[0]?.product
+    expect(product).toBeDefined()
+    expect(product).toEqual({ id: 'p1', nom: 'Product', prixVenteAchat: 300 })
+    expect('prixAchatAchat' in product!).toBe(false)
+    expect('prixUnitaireAchat' in product!).toBe(false)
+    expect('margeCoefficientAchat' in product!).toBe(false)
+  })
+
+  it('handles arrays at the top level', () => {
+    const products = [
+      { id: '1', prixAchatAchat: 100, nom: 'A' },
+      { id: '2', prixAchatAchat: 200, nom: 'B' },
+    ]
+
+    const result = stripCostFieldsDeep(products)
+
+    expect(result).toEqual([
+      { id: '1', nom: 'A' },
+      { id: '2', nom: 'B' },
+    ])
+  })
+
+  it('handles empty arrays', () => {
+    expect(stripCostFieldsDeep([])).toEqual([])
+  })
+
+  it('handles empty objects', () => {
+    expect(stripCostFieldsDeep({})).toEqual({})
+  })
+
+  it('preserves non-cost nested objects', () => {
+    const data = {
+      id: '1',
+      metadata: {
+        createdAt: '2024-01-01',
+        tags: ['a', 'b'],
+      },
+    }
+
+    const result = stripCostFieldsDeep(data)
+
+    expect(result).toEqual(data)
+  })
+
+  it('strips cost fields from unknown nested keys (fallback behavior)', () => {
+    const data = {
+      id: '1',
+      someNewRelation: {
+        id: 'r1',
+        prixAchatAchat: 999,
+        prixVenteAchat: 500,
+        nom: 'Surprise product',
+      },
+    }
+
+    const result = stripCostFieldsDeep(data) as typeof data
+
+    expect(result.someNewRelation).toEqual({
+      id: 'r1',
+      prixVenteAchat: 500,
+      nom: 'Surprise product',
+    })
+    expect('prixAchatAchat' in result.someNewRelation).toBe(false)
+  })
+
+  it('does not mutate the original data', () => {
+    const product = {
+      id: '1',
+      prixAchatAchat: 100,
+      nested: { product: { id: 'p1', prixAchatAchat: 50 } },
+    }
+    const original = JSON.parse(JSON.stringify(product))
+
+    stripCostFieldsDeep(product)
+
+    expect(product).toEqual(original)
+  })
+})

--- a/src/lib/utils/strip-cost-fields.ts
+++ b/src/lib/utils/strip-cost-fields.ts
@@ -28,11 +28,19 @@ export function stripCostFieldsFromProduct<T extends Record<string, unknown>>(pr
 
 /**
  * Recursively strips cost/margin fields from any data structure containing products.
- * Handles all nesting patterns:
+ * Handles known nesting patterns and falls back to stripping cost fields from any
+ * object that directly contains them — ensuring new Prisma includes don't silently
+ * leak cost data.
+ *
+ * Known nesting patterns:
  * - Direct product objects (with prixAchat* fields)
  * - kitProducts[].product
  * - projectKits[].kit.kitProducts[].product
  * - products[] arrays
+ *
+ * NOTE: When adding new Prisma includes that nest product data under a new key,
+ * the fallback will catch cost fields, but adding the key explicitly here improves
+ * clarity and performance.
  */
 export function stripCostFieldsDeep<T>(data: T): T {
   if (data === null || data === undefined || typeof data !== 'object') {
@@ -44,21 +52,19 @@ export function stripCostFieldsDeep<T>(data: T): T {
   }
 
   const obj = data as Record<string, unknown>
+  const hasCostFields = Object.keys(obj).some(isCostField)
+
+  if (hasCostFields) {
+    return stripCostFieldsFromProduct(obj) as T
+  }
+
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(obj)) {
-    if (key === 'product' && value !== null && typeof value === 'object') {
-      result[key] = stripCostFieldsFromProduct(value as Record<string, unknown>)
-    } else if (key === 'products' && Array.isArray(value)) {
-      result[key] = value.map((p) =>
-        p !== null && typeof p === 'object'
-          ? stripCostFieldsFromProduct(p as Record<string, unknown>)
-          : p,
-      )
-    } else if ((key === 'kitProducts' || key === 'projectKits') && Array.isArray(value)) {
-      result[key] = value.map((item) => stripCostFieldsDeep(item))
-    } else if (key === 'kit' && value !== null && typeof value === 'object') {
-      result[key] = stripCostFieldsDeep(value)
+    if (value !== null && typeof value === 'object') {
+      result[key] = Array.isArray(value)
+        ? value.map((item) => stripCostFieldsDeep(item))
+        : stripCostFieldsDeep(value)
     } else {
       result[key] = value
     }

--- a/src/lib/utils/strip-cost-fields.ts
+++ b/src/lib/utils/strip-cost-fields.ts
@@ -1,0 +1,68 @@
+/**
+ * Strips internal cost and margin fields from product data before sending to non-admin users.
+ * Defense in depth: ensures prixAchat*, prixUnitaire*, and margeCoefficient* fields
+ * are never exposed to USER-role users, even if frontend checks are bypassed.
+ */
+
+const COST_FIELD_PREFIXES = ['prixAchat', 'prixUnitaire', 'margeCoefficient'] as const
+
+function isCostField(key: string): boolean {
+  return COST_FIELD_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
+
+/**
+ * Strips cost/margin fields from a single product-like object.
+ * Returns a new object without prixAchat*, prixUnitaire*, margeCoefficient* fields.
+ */
+export function stripCostFieldsFromProduct<T extends Record<string, unknown>>(product: T): T {
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(product)) {
+    if (!isCostField(key)) {
+      result[key] = value
+    }
+  }
+
+  return result as T
+}
+
+/**
+ * Recursively strips cost/margin fields from any data structure containing products.
+ * Handles all nesting patterns:
+ * - Direct product objects (with prixAchat* fields)
+ * - kitProducts[].product
+ * - projectKits[].kit.kitProducts[].product
+ * - products[] arrays
+ */
+export function stripCostFieldsDeep<T>(data: T): T {
+  if (data === null || data === undefined || typeof data !== 'object') {
+    return data
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((item) => stripCostFieldsDeep(item)) as T
+  }
+
+  const obj = data as Record<string, unknown>
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'product' && value !== null && typeof value === 'object') {
+      result[key] = stripCostFieldsFromProduct(value as Record<string, unknown>)
+    } else if (key === 'products' && Array.isArray(value)) {
+      result[key] = value.map((p) =>
+        p !== null && typeof p === 'object'
+          ? stripCostFieldsFromProduct(p as Record<string, unknown>)
+          : p,
+      )
+    } else if ((key === 'kitProducts' || key === 'projectKits') && Array.isArray(value)) {
+      result[key] = value.map((item) => stripCostFieldsDeep(item))
+    } else if (key === 'kit' && value !== null && typeof value === 'object') {
+      result[key] = stripCostFieldsDeep(value)
+    } else {
+      result[key] = value
+    }
+  }
+
+  return result as T
+}


### PR DESCRIPTION
## Summary

- Restrict cost and margin field visibility (prixAchat*, prixUnitaire*, margeCoefficient*) to ADMIN and DEV roles only
- Server-side defense-in-depth: all product, kit, and project API endpoints now strip cost fields before responding to USER-role requests
- Client-side awareness via `useCanViewCosts` hook to adjust pricing analysis UI layout

## Related Issue

TRI-108

## Changes

### Server-side cost field stripping
- Added `stripCostFieldsFromProduct` utility for flat product objects
- Added `stripCostFieldsDeep` utility for recursive stripping across nested structures (kits, project kits)
- Applied stripping to all GET endpoints:
  - `GET /api/products` and `GET /api/products/[id]`
  - `GET /api/kits` and `GET /api/kits/[id]`
  - `GET /api/projects` and `GET /api/projects/[id]`
  - `GET /api/projects/[id]/kits`

### Client-side UI gating
- Added `useCanViewCosts` hook wrapping role check
- Updated `PricingDetailedAnalysis` component to hide cost-related cards (purchase cost, margin) for non-admin users

### Files changed (~10 files)
- `src/lib/utils/strip-cost-fields.ts` — new utility
- `src/hooks/use-can-view-costs.ts` — new hook
- 7 API route files — added cost stripping logic
- `src/components/projects/pricing-detailed-analysis.tsx` — conditional UI

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [ ] Unit tests pass
- [x] Manual testing done
