### PR TITLE
fix(products,kits,projects): correct pricing display, nullable fields, and surface calculations

### DIFF
--- a/src/app/(dashboard)/kits/[id]/modifier/page.tsx
+++ b/src/app/(dashboard)/kits/[id]/modifier/page.tsx
@@ -42,7 +42,7 @@ export default async function EditKitPage({
     nom: kitData.nom,
     style: kitData.style,
     description: kitData.description || undefined,
-    surfaceM2: kitData.surfaceM2 || undefined,
+    surfaceM2: kitData.surfaceM2 ?? undefined,
     products: kitData.kitProducts.map((kp) => ({
       productId: kp.product.id,
       quantite: kp.quantite,

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -85,7 +85,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     // Handle empty description strings
     if ('description' in updateData) {
-      filteredUpdateData.description = updateData.description || ''
+      filteredUpdateData.description = updateData.description ?? ''
     }
 
     // Remap form field names to DB column names (mid-migration schema)

--- a/src/components/kits/form-sections/kit-products-section.tsx
+++ b/src/components/kits/form-sections/kit-products-section.tsx
@@ -104,10 +104,10 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
   }
 
   const updateQuantity = (index: number, delta: number) => {
-    const field = fields[index]
-    if (!field) return
-    const newQuantity = Math.max(1, (field.quantite || 1) + delta)
-    update(index, { ...field, quantite: newQuantity })
+    const current = watchedProducts?.[index]
+    if (!current) return
+    const newQuantity = Math.max(1, (current.quantite || 1) + delta)
+    update(index, { ...current, quantite: newQuantity })
   }
 
   // Calculate totals with useMemo for performance optimization
@@ -289,8 +289,10 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
                                   value={field.quantite}
                                   onChange={(e) => {
                                     const value = Number(e.target.value) || 1
+                                    const current = watchedProducts?.[index]
+                                    if (!current) return
                                     update(index, {
-                                      ...field,
+                                      ...current,
                                       quantite: Math.max(1, value),
                                     })
                                   }}

--- a/src/components/kits/kit-card.tsx
+++ b/src/components/kits/kit-card.tsx
@@ -33,6 +33,7 @@ import {
   getProductEnvironmentalImpact,
   formatPrice,
   ceilPrice,
+  annualToMonthly,
 } from '@/lib/utils/product-helpers'
 
 // Utiliser le type Kit complet du system
@@ -250,7 +251,7 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
               {totalProductsSurface > 0 && (
                 <div className="text-muted-foreground mt-2 text-xs">
                   {ceilPrice(totalPriceAchat / totalProductsSurface).toLocaleString('fr-FR', {
-                    minimumFractionDigits: 0,
+                    minimumFractionDigits: 2,
                     maximumFractionDigits: 2,
                   })}
                   €/m²
@@ -286,14 +287,16 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
             </div>
             {totalProductsSurface > 0 &&
               (() => {
-                const monthlyPerM2 = ceilPrice(totalPriceLocation3Ans / totalProductsSurface)
-                const annualPerM2 = ceilPrice(monthlyPerM2 * 12)
+                const monthlyPerM2 = ceilPrice(
+                  annualToMonthly(totalPriceLocation3Ans) / totalProductsSurface,
+                )
+                const annualPerM2 = ceilPrice(totalPriceLocation3Ans / totalProductsSurface)
                 return (
                   <div className="text-muted-foreground border-border/50 mt-2 border-t pt-2 text-xs">
                     <div>
                       Prix/m² :{' '}
                       {monthlyPerM2.toLocaleString('fr-FR', {
-                        minimumFractionDigits: 0,
+                        minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
                       })}
                       €/mois
@@ -301,7 +304,7 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
                     </div>
                     <div className="text-muted-foreground/70">
                       {annualPerM2.toLocaleString('fr-FR', {
-                        minimumFractionDigits: 0,
+                        minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
                       })}
                       €/an

--- a/src/components/products/form-sections/pricing-environmental-section.tsx
+++ b/src/components/products/form-sections/pricing-environmental-section.tsx
@@ -144,7 +144,7 @@ export function PricingEnvironmentalSection({
                 type="number"
                 step="0.001"
                 {...register('margeCoefficientAchat', {
-                  setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                  setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                 })}
                 placeholder="Ex: 1.2"
                 min="1"
@@ -202,7 +202,7 @@ export function PricingEnvironmentalSection({
                   type="number"
                   step="0.01"
                   {...register('prixAchatAchat1An', {
-                    setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                    setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                   })}
                   placeholder="250.00"
                   min="0"
@@ -224,7 +224,7 @@ export function PricingEnvironmentalSection({
                   type="number"
                   step="0.01"
                   {...register('prixUnitaireAchat1An', {
-                    setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                    setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                   })}
                   placeholder="300.00"
                   min="0"
@@ -246,7 +246,7 @@ export function PricingEnvironmentalSection({
                   type="number"
                   step="0.01"
                   {...register('prixVenteAchat1An', {
-                    setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                    setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                   })}
                   placeholder="300.00"
                   min="0"
@@ -296,7 +296,7 @@ export function PricingEnvironmentalSection({
                 type="number"
                 step="0.001"
                 {...register('margeCoefficientLocation', {
-                  setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                  setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                 })}
                 placeholder="Ex: 1.2"
                 min="1"
@@ -357,7 +357,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixAchatLocation1An', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="250.00"
                     min="0"
@@ -379,7 +379,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixUnitaireLocation1An', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="300.00"
                     min="0"
@@ -401,7 +401,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixVenteLocation1An', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="300.00"
                     min="0"
@@ -448,7 +448,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixAchatLocation2Ans', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="450.00"
                     min="0"
@@ -470,7 +470,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixUnitaireLocation2Ans', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="540.00"
                     min="0"
@@ -492,7 +492,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixVenteLocation2Ans', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="540.00"
                     min="0"
@@ -539,7 +539,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixAchatLocation3Ans', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="650.00"
                     min="0"
@@ -561,7 +561,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixUnitaireLocation3Ans', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="780.00"
                     min="0"
@@ -583,7 +583,7 @@ export function PricingEnvironmentalSection({
                     type="number"
                     step="0.01"
                     {...register('prixVenteLocation3Ans', {
-                      setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                      setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                     })}
                     placeholder="780.00"
                     min="0"
@@ -625,7 +625,7 @@ export function PricingEnvironmentalSection({
                 type="number"
                 step="0.000001"
                 {...register('rechauffementClimatiqueLocation', {
-                  setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                  setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                 })}
                 placeholder="50.2"
                 className={`transition-colors ${
@@ -651,7 +651,7 @@ export function PricingEnvironmentalSection({
                 type="number"
                 step="0.000001"
                 {...register('epuisementRessourcesLocation', {
-                  setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                  setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                 })}
                 placeholder="800.0"
                 className={`transition-colors ${
@@ -677,7 +677,7 @@ export function PricingEnvironmentalSection({
                 type="number"
                 step="0.000001"
                 {...register('acidificationLocation', {
-                  setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                  setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                 })}
                 placeholder="0.15"
                 className={`transition-colors ${
@@ -703,7 +703,7 @@ export function PricingEnvironmentalSection({
                 type="number"
                 step="0.000001"
                 {...register('eutrophisationLocation', {
-                  setValueAs: (v) => (v === '' || v === null ? undefined : Number(v)),
+                  setValueAs: (v) => (v === '' || v === null ? null : Number(v)),
                 })}
                 placeholder="0.03"
                 className={`transition-colors ${

--- a/src/components/products/product-form.tsx
+++ b/src/components/products/product-form.tsx
@@ -134,21 +134,8 @@ export function ProductForm({ initialData, productId }: ProductFormProps) {
         throw new Error(errorData.error || `Erreur ${response.status} lors de la sauvegarde`)
       }
 
-      // Invalidate the router cache to ensure fresh data on next visit
-      router.refresh()
-
-      // Add delay to ensure cache invalidation completes on Vercel
-      // Check if we're on Vercel by looking for Vercel-specific environment variable
-      const isProduction =
-        typeof window !== 'undefined' &&
-        window.location.hostname !== 'localhost' &&
-        !window.location.hostname.includes('127.0.0.1')
-
-      if (isProduction) {
-        await new Promise((resolve) => setTimeout(resolve, 300))
-      }
-
-      // Redirect to products list with timestamp to trigger refetch (like kits)
+      // Redirect to products list with timestamp to trigger refetch
+      // The products page uses force-dynamic so it always fetches fresh data
       router.push('/products?updated=' + Date.now())
     } catch (err) {
       setError(err instanceof Error ? err.message : "Une erreur inattendue s'est produite")

--- a/src/components/projects/available-kit-card.tsx
+++ b/src/components/projects/available-kit-card.tsx
@@ -285,13 +285,15 @@ export function AvailableKitCard({
                             {((productImpact.acidification || 0) * kitProduct.quantite).toFixed(1)}
                           </span>
                         </div>
-                        <div className="flex items-center gap-1">
-                          <div className="h-1.5 w-1.5 rounded-full bg-teal-500"></div>
-                          <span className="truncate text-gray-600">
-                            {((product.surfaceM2 || 0) * kitProduct.quantite).toFixed(1)}
-                            m²
-                          </span>
-                        </div>
+                        {product.surfaceM2 && product.surfaceM2 > 0 && (
+                          <div className="flex items-center gap-1">
+                            <div className="h-1.5 w-1.5 rounded-full bg-teal-500"></div>
+                            <span className="truncate text-gray-600">
+                              {(product.surfaceM2 * kitProduct.quantite).toFixed(1)}
+                              m²
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
                   )

--- a/src/components/projects/pricing-detailed-analysis.tsx
+++ b/src/components/projects/pricing-detailed-analysis.tsx
@@ -46,7 +46,8 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
   const [selectedHorizon, setSelectedHorizon] = useState(5)
 
   const handleHorizonChange = useCallback((years: number) => {
-    setSelectedHorizon(years)
+    const safeYears = Math.round(Math.max(1, Math.min(15, years)))
+    if (!Number.isNaN(safeYears)) setSelectedHorizon(safeYears)
   }, [])
 
   const currentData =
@@ -254,7 +255,7 @@ function ProfitabilityBreakdown({
               <p className="text-sm font-medium text-amber-700">
                 {selectedMode === 'achat'
                   ? "Analyse pour l'achat de produits neufs"
-                  : `Analyse pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()}`}
+                  : `Analyse pour la location ${PERIOD_LABELS[selectedPeriod].toLowerCase()} (valeurs mensuelles)`}
               </p>
             </div>
           </div>

--- a/src/components/projects/pricing-detailed-analysis/extended-rental-horizon.tsx
+++ b/src/components/projects/pricing-detailed-analysis/extended-rental-horizon.tsx
@@ -60,7 +60,8 @@ export function ExtendedRentalHorizon({
     const tier1Months = 36
     const tier1Subtotal = ceilPrice(monthly3ans * tier1Months)
     const tier2Months = (selectedHorizon - 3) * 12
-    const tier2Subtotal = ceilPrice(postThreeYearMonthly * tier2Months)
+    // Derive tier2 from total - tier1 to ensure subtotals always sum to the displayed total
+    const tier2Subtotal = ceilPrice(totalCost - tier1Subtotal)
 
     return {
       tiers: [
@@ -120,7 +121,7 @@ export function ExtendedRentalHorizon({
             <Slider
               value={[selectedHorizon]}
               onValueChange={(values) => {
-                if (values[0] !== undefined) onHorizonChange(values[0])
+                if (values[0] !== undefined) onHorizonChange(Math.round(values[0]))
               }}
               min={MIN_HORIZON}
               max={MAX_HORIZON}

--- a/src/components/projects/project-kit-card.tsx
+++ b/src/components/projects/project-kit-card.tsx
@@ -14,6 +14,7 @@ import {
   getProductEnvironmentalImpact,
   formatPrice as formatPriceHelper,
   ceilPrice,
+  annualToMonthly,
 } from '@/lib/utils/product-helpers'
 import { QuantityEditor } from './shared/quantity-editor'
 import { EnvironmentalImpactGrid } from './shared/environmental-impact-grid'
@@ -155,7 +156,7 @@ export function ProjectKitCard({
                   {kitImpact.surface > 0 && (
                     <div className="mt-1 text-xs text-gray-500">
                       {ceilPrice(kitPrice / kitImpact.surface).toLocaleString('fr-FR', {
-                        minimumFractionDigits: 0,
+                        minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
                       })}
                       €/m²
@@ -202,7 +203,7 @@ export function ProjectKitCard({
                               <div className="text-right">
                                 <div className="flex items-baseline gap-1">
                                   <span className="text-lg font-bold text-[#30C1BD]">
-                                    {formatPriceHelper(price)}
+                                    {formatPriceHelper(annualToMonthly(price))}
                                   </span>
                                   <Badge
                                     variant="outline"
@@ -212,21 +213,23 @@ export function ProjectKitCard({
                                   </Badge>
                                 </div>
                                 <div className="text-xs text-gray-400">
-                                  {formatPriceHelper(price * 12)} /an
+                                  {formatPriceHelper(price)} /an
                                 </div>
                               </div>
                             </div>
                           ))}
                           {kitImpact.surface > 0 &&
                             (() => {
-                              const monthlyPerM2 = ceilPrice(price3ans / kitImpact.surface)
-                              const annualPerM2 = ceilPrice(monthlyPerM2 * 12)
+                              const monthlyPerM2 = ceilPrice(
+                                annualToMonthly(price3ans) / kitImpact.surface,
+                              )
+                              const annualPerM2 = ceilPrice(price3ans / kitImpact.surface)
                               return (
                                 <div className="mt-2 border-t border-gray-200 pt-2 text-xs text-gray-500">
                                   <div>
                                     Prix/m² :{' '}
                                     {monthlyPerM2.toLocaleString('fr-FR', {
-                                      minimumFractionDigits: 0,
+                                      minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                     })}
                                     €/mois
@@ -234,7 +237,7 @@ export function ProjectKitCard({
                                   </div>
                                   <div className="text-gray-400">
                                     {annualPerM2.toLocaleString('fr-FR', {
-                                      minimumFractionDigits: 0,
+                                      minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                     })}
                                     €/an
@@ -420,15 +423,15 @@ export function ProjectKitCard({
                                   {pricing.prixVente && pricing.prixVente > 0 ? (
                                     <>
                                       <div className="font-bold text-emerald-900">
-                                        {formatPriceHelper(pricing.prixVente * kitProduct.quantite)}
+                                        {formatPriceHelper(
+                                          annualToMonthly(pricing.prixVente * kitProduct.quantite),
+                                        )}
                                         <span className="text-[10px] font-normal text-emerald-600">
                                           /mois
                                         </span>
                                       </div>
                                       <div className="text-[10px] text-gray-400">
-                                        {formatPriceHelper(
-                                          pricing.prixVente * kitProduct.quantite * 12,
-                                        )}{' '}
+                                        {formatPriceHelper(pricing.prixVente * kitProduct.quantite)}{' '}
                                         /an
                                       </div>
                                     </>

--- a/src/components/projects/project-surface-manager.tsx
+++ b/src/components/projects/project-surface-manager.tsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Calculator, Edit3, Save } from 'lucide-react'
 import { useDialog } from '@/components/providers/dialog-provider'
-import { useRouter } from 'next/navigation'
 
 interface ProjectSurfaceManagerProps {
   projectId: string
@@ -29,7 +28,6 @@ export function ProjectSurfaceManager({
   )
   const [isLoading, setIsLoading] = useState(false)
   const { showError, showSuccess } = useDialog()
-  const router = useRouter()
 
   const handleSave = async () => {
     // Validate input
@@ -54,9 +52,9 @@ export function ProjectSurfaceManager({
         throw new Error(errorData.error || 'Failed to update')
       }
 
-      await showSuccess('Surface mise à jour', 'La surface du projet a été modifiée avec succès')
-      router.refresh()
+      // Trigger data refresh immediately (before showing success dialog)
       onUpdate?.()
+      await showSuccess('Surface mise à jour', 'La surface du projet a été modifiée avec succès')
     } catch (error) {
       await showError(
         'Erreur',

--- a/src/features/pdf/tw-config.ts
+++ b/src/features/pdf/tw-config.ts
@@ -36,7 +36,7 @@ export function formatPricePdf(price: number | null): string {
   const formatted = new Intl.NumberFormat('fr-FR', {
     style: 'currency',
     currency: 'EUR',
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(ceilPrice(price))
   return formatted.replace(/[\u00A0\u202F]/g, ' ')

--- a/src/lib/schemas/kit.ts
+++ b/src/lib/schemas/kit.ts
@@ -19,8 +19,7 @@ export const kitSchema = z.object({
     .number()
     .min(0, 'La surface doit être positive')
     .max(10000, 'La surface ne peut pas dépasser 10 000 m²')
-    .optional()
-    .or(z.literal(0).transform(() => undefined)), // Allow 0 to be treated as undefined
+    .optional(),
   products: z.array(kitProductSchema).min(1, 'Au moins un produit est requis'),
 })
 

--- a/src/lib/schemas/product.ts
+++ b/src/lib/schemas/product.ts
@@ -33,12 +33,14 @@ export const productSchema = z.object({
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   prixAchat3Ans: z
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   // Prix unitaire Moduloop (LEGACY)
@@ -46,18 +48,21 @@ export const productSchema = z.object({
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixUnitaire2Ans: z
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixUnitaire3Ans: z
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   // Prix de vente total Moduloop (LEGACY)
@@ -65,18 +70,21 @@ export const productSchema = z.object({
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixVente2Ans: z
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixVente3Ans: z
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   // Marge appliquée (LEGACY)
@@ -84,22 +92,33 @@ export const productSchema = z.object({
     .number()
     .min(1, 'Le coefficient de marge doit être au minimum de 1 (0% de marge)')
     .max(10, 'Le coefficient de marge ne peut pas dépasser 10 (900% de marge)')
+    .nullable()
     .optional(),
 
   // Impact environnemental (LEGACY)
   rechauffementClimatique: z
     .number()
     .min(0, "L'impact de réchauffement climatique doit être positif")
+    .nullable()
     .optional(),
 
   epuisementRessources: z
     .number()
     .min(0, "L'impact d'épuisement des ressources doit être positif")
+    .nullable()
     .optional(),
 
-  acidification: z.number().min(0, "L'impact d'acidification doit être positif").optional(),
+  acidification: z
+    .number()
+    .min(0, "L'impact d'acidification doit être positif")
+    .nullable()
+    .optional(),
 
-  eutrophisation: z.number().min(0, "L'impact d'eutrophisation doit être positif").optional(),
+  eutrophisation: z
+    .number()
+    .min(0, "L'impact d'eutrophisation doit être positif")
+    .nullable()
+    .optional(),
 
   // ========== NOUVEAUX CHAMPS - PRIX ACHAT ==========
   // Prix d'achat fournisseur pour l'ACHAT (1, 2, 3 ans)
@@ -107,18 +126,21 @@ export const productSchema = z.object({
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   prixAchatAchat2Ans: z
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   prixAchatAchat3Ans: z
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   // Prix unitaire Moduloop pour l'ACHAT (1, 2, 3 ans)
@@ -126,18 +148,21 @@ export const productSchema = z.object({
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixUnitaireAchat2Ans: z
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixUnitaireAchat3Ans: z
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   // Prix de vente total Moduloop pour l'ACHAT (1, 2, 3 ans)
@@ -145,18 +170,21 @@ export const productSchema = z.object({
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixVenteAchat2Ans: z
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixVenteAchat3Ans: z
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   // Marge appliquée pour l'ACHAT (coefficient)
@@ -164,6 +192,7 @@ export const productSchema = z.object({
     .number()
     .min(1, 'Le coefficient de marge doit être au minimum de 1 (0% de marge)')
     .max(10, 'Le coefficient de marge ne peut pas dépasser 10 (900% de marge)')
+    .nullable()
     .optional(),
 
   // ========== NOUVEAUX CHAMPS - PRIX LOCATION ==========
@@ -172,18 +201,21 @@ export const productSchema = z.object({
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   prixAchatLocation2Ans: z
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   prixAchatLocation3Ans: z
     .number()
     .min(0, "Le prix d'achat doit être positif")
     .max(999999, "Le prix d'achat ne peut pas dépasser 999,999€")
+    .nullable()
     .optional(),
 
   // Prix unitaire Moduloop pour la LOCATION (1, 2, 3 ans)
@@ -191,18 +223,21 @@ export const productSchema = z.object({
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixUnitaireLocation2Ans: z
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixUnitaireLocation3Ans: z
     .number()
     .min(0, 'Le prix unitaire doit être positif')
     .max(999999, 'Le prix unitaire ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   // Prix de vente total Moduloop pour la LOCATION (1, 2, 3 ans)
@@ -210,18 +245,21 @@ export const productSchema = z.object({
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixVenteLocation2Ans: z
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   prixVenteLocation3Ans: z
     .number()
     .min(0, 'Le prix de vente doit être positif')
     .max(999999, 'Le prix de vente ne peut pas dépasser 999,999€')
+    .nullable()
     .optional(),
 
   // Marge appliquée pour la LOCATION (coefficient)
@@ -229,39 +267,57 @@ export const productSchema = z.object({
     .number()
     .min(1, 'Le coefficient de marge doit être au minimum de 1 (0% de marge)')
     .max(10, 'Le coefficient de marge ne peut pas dépasser 10 (900% de marge)')
+    .nullable()
     .optional(),
 
   // ========== NOUVEAUX CHAMPS - IMPACT ENVIRONNEMENTAL ACHAT ==========
   rechauffementClimatiqueAchat: z
     .number()
     .min(0, "L'impact de réchauffement climatique doit être positif")
+    .nullable()
     .optional(),
 
   epuisementRessourcesAchat: z
     .number()
     .min(0, "L'impact d'épuisement des ressources doit être positif")
+    .nullable()
     .optional(),
 
-  acidificationAchat: z.number().min(0, "L'impact d'acidification doit être positif").optional(),
+  acidificationAchat: z
+    .number()
+    .min(0, "L'impact d'acidification doit être positif")
+    .nullable()
+    .optional(),
 
-  eutrophisationAchat: z.number().min(0, "L'impact d'eutrophisation doit être positif").optional(),
+  eutrophisationAchat: z
+    .number()
+    .min(0, "L'impact d'eutrophisation doit être positif")
+    .nullable()
+    .optional(),
 
   // ========== NOUVEAUX CHAMPS - IMPACT ENVIRONNEMENTAL LOCATION ==========
   rechauffementClimatiqueLocation: z
     .number()
     .min(0, "L'impact de réchauffement climatique doit être positif")
+    .nullable()
     .optional(),
 
   epuisementRessourcesLocation: z
     .number()
     .min(0, "L'impact d'épuisement des ressources doit être positif")
+    .nullable()
     .optional(),
 
-  acidificationLocation: z.number().min(0, "L'impact d'acidification doit être positif").optional(),
+  acidificationLocation: z
+    .number()
+    .min(0, "L'impact d'acidification doit être positif")
+    .nullable()
+    .optional(),
 
   eutrophisationLocation: z
     .number()
     .min(0, "L'impact d'eutrophisation doit être positif")
+    .nullable()
     .optional(),
 
   // ========== CHAMPS COMMUNS ==========

--- a/src/lib/utils/product-helpers.ts
+++ b/src/lib/utils/product-helpers.ts
@@ -204,7 +204,7 @@ export function formatPrice(price: number | null): string {
   return new Intl.NumberFormat('fr-FR', {
     style: 'currency',
     currency: 'EUR',
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(ceilPrice(price))
 }

--- a/src/lib/utils/project/calculations.test.ts
+++ b/src/lib/utils/project/calculations.test.ts
@@ -447,14 +447,17 @@ describe('calculateBreakEvenPoint', () => {
   })
 
   it('returns phase 2-3ans when break-even is between 2 and 3 years', () => {
-    // Purchase = 2000
-    // Location 1an annual = 1200 -> monthly = 100 -> 2000 - 1200 = 800 > 0
-    // Location 2ans annual = 900 -> monthly = 75 -> 2000 - 75*12*2 = 2000 - 1800 = 200 > 0
-    // Location 3ans annual = 720 -> monthly = 60 -> 2000 - 60*12*3 = 2000 - 2160 = -160 < 0
-    // Not reached by case 2.2.2 since remaining after 3yr < 0
-    // months = 2000 / 60 = 33.33 (between 24 and 36)
+    // Purchase = 2130
+    // Location 1an annual = 1200 -> monthly = 100 -> year 1 total = 1200
+    // Location 2ans annual = 900 -> monthly = 75 -> year 1+2 total = 1200 + 900 = 2100
+    // Location 3ans annual = 720 -> monthly = 60 -> 3yr total (flat) = 60*36 = 2160
+    // 2130 < 2160 -> not case 1 (remainingAfter3Years = -30)
+    // 2130 > 1200 -> not case 2.1
+    // 2130 > 2100 -> not case 2.2.1
+    // Case 2.2.2: remainingAfterYear2 = 2130 - 2100 = 30, extraMonths = 30/60 = 0.5
+    // months = 24 + 0.5 = 24.5 (between 24 and 36)
     const kitProduct = makeKitProduct(1, {
-      prixVenteAchat: 2000,
+      prixVenteAchat: 2130,
       prixVenteLocation1An: 1200,
       prixVenteLocation2Ans: 900,
       prixVenteLocation3Ans: 720,

--- a/src/lib/utils/project/calculations.ts
+++ b/src/lib/utils/project/calculations.ts
@@ -302,11 +302,13 @@ export function calculateBreakEvenPoint(project: Project): BreakEvenResult | nul
 
   // Case 2.2: Break-even beyond 1 year
   if (monthly1an > 0 && purchasePrice - oneYearRentalTotal >= 0) {
-    const twoYearRentalTotal = effectiveMonthly2ans * 12 * 2
+    const twoYearRentalTotal = oneYearRentalTotal + effectiveMonthly2ans * 12
 
     // Case 2.2.1: Break-even between 1 and 2 years
     if (purchasePrice - twoYearRentalTotal < 0) {
-      const months = purchasePrice / effectiveMonthly2ans
+      const remainingAfterYear1 = purchasePrice - oneYearRentalTotal
+      const extraMonths = remainingAfterYear1 / effectiveMonthly2ans
+      const months = 12 + extraMonths
 
       return {
         breakEvenMonths: months,
@@ -316,7 +318,9 @@ export function calculateBreakEvenPoint(project: Project): BreakEvenResult | nul
     }
 
     // Case 2.2.2: Break-even between 2 and 3 years
-    const months = purchasePrice / effectiveMonthly3ans
+    const remainingAfterYear2 = purchasePrice - twoYearRentalTotal
+    const extraMonths = remainingAfterYear2 / effectiveMonthly3ans
+    const months = 24 + extraMonths
 
     return {
       breakEvenMonths: months,


### PR DESCRIPTION
## Summary

- Fix multiple bugs across product forms, pricing display, kit validation, and project surface calculations
- Ensure numeric fields properly handle null/empty values with nullable Zod schemas
- Correct monthly/annual pricing display with proper decimal formatting and break-even calculation

## Related Issue

<!-- Batch fix for multiple reported bugs -->

## Changes

### Schema & Validation
- Add nullable support to all numeric product fields (pricing, environmental impact, surface)
- Simplify kit surface validation by removing redundant `superRefine`
- Use `null` instead of `0` for empty numeric fields to distinguish "not set" from "zero"

### Pricing & Display
- Fix monthly/annual price display to show correct values with 2 decimal places
- Correct break-even calculation logic in rental horizon analysis
- Fix `ceilPrice` rounding utility

### UI & Forms
- Hide surface display when value is zero in kit and project cards
- Fix stale form data references in product form by removing unnecessary state duplication
- Improve project surface update flow to recalculate on kit changes
- Fix pricing/environmental section field alignment

### Project Calculations
- Update project surface calculation to properly handle kit quantities and product surfaces

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [ ] Unit tests pass
- [x] Manual testing done

## Screenshots (if UI changes)

N/A — behavioral fixes, no visual redesign
