### PR TITLE
feat(projects): add searchable user combobox for admin/dev project viewing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           AUTH_SECRET: e2e-test-secret-not-for-production
           NEXTAUTH_SECRET: e2e-test-nextauth-secret
           NEXT_PUBLIC_APP_URL: http://localhost:3001
+          BETTER_AUTH_URL: http://localhost:3001
           GOOGLE_CLIENT_ID: fake-google-client-id
           GOOGLE_CLIENT_SECRET: fake-google-client-secret
 

--- a/e2e/kits.spec.ts
+++ b/e2e/kits.spec.ts
@@ -34,6 +34,7 @@ test.describe('Kit CRUD', () => {
         nom: kitName,
         style: 'Moderne',
         description: 'E2E test kit',
+        surfaceM2: 25,
         products: [{ productId: product.id, quantite: 2 }],
       },
     })
@@ -78,6 +79,7 @@ test.describe('Kit CRUD', () => {
         nom: 'Kit To Edit',
         style: 'Classique',
         description: 'A kit to edit',
+        surfaceM2: 25,
         products: [{ productId: product.id, quantite: 1 }],
       },
     })

--- a/e2e/kits.spec.ts
+++ b/e2e/kits.spec.ts
@@ -51,9 +51,19 @@ test.describe('Kit CRUD', () => {
   test('should navigate to kit form page', async ({ page }) => {
     await page.goto('/kits/nouveau')
 
-    // Verify the form page loads with expected sections
+    // Step 1: Verify general info section is visible
     await expect(page.getByRole('heading', { name: 'Nouveau kit' })).toBeVisible()
     await expect(page.getByText('Informations générales')).toBeVisible()
+
+    // Fill required step 1 fields to pass validation
+    await page.locator('#nom').fill('Test Kit')
+    await page.locator('#style').fill('Moderne')
+    await page.locator('#surfaceM2').fill('25')
+
+    // Navigate to step 2 by clicking "Suivant"
+    await page.getByRole('button', { name: /Suivant/ }).click()
+
+    // Step 2: Verify products section and submit button
     await expect(page.getByText('Produits du kit')).toBeVisible()
     await expect(page.getByTestId('kit-submit')).toBeVisible()
   })
@@ -92,18 +102,18 @@ test.describe('Kit CRUD', () => {
     // Navigate to edit page
     await page.goto(`/kits/${kit.id}/modifier`)
 
-    // Open general info accordion if needed
+    // Step 1: Update the name in general info
     const nomInput = page.locator('#nom')
-    if (!(await nomInput.isVisible())) {
-      await page.getByText('Informations générales').click()
-    }
+    await nomInput.waitFor({ state: 'visible', timeout: 10_000 })
 
-    // Change the name
     const updatedName = `Updated Kit ${Date.now()}`
     await nomInput.clear()
     await nomInput.fill(updatedName)
 
-    // Submit
+    // Navigate to step 2
+    await page.getByRole('button', { name: /Suivant/ }).click()
+
+    // Submit from step 2
     await page.getByTestId('kit-submit').click()
 
     // Should redirect to kits list

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,7 @@ const TEST_ENV = {
   AUTH_SECRET: 'e2e-test-secret-not-for-production',
   NEXTAUTH_SECRET: 'e2e-test-nextauth-secret',
   NEXT_PUBLIC_APP_URL: BASE_URL,
+  BETTER_AUTH_URL: BASE_URL,
   GOOGLE_CLIENT_ID: 'fake-google-client-id',
   GOOGLE_CLIENT_SECRET: 'fake-google-client-secret',
 }
@@ -37,6 +38,9 @@ export default defineConfig({
 
   use: {
     baseURL: BASE_URL,
+    extraHTTPHeaders: {
+      Origin: BASE_URL,
+    },
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/src/app/(dashboard)/kits/nouveau/page.tsx
+++ b/src/app/(dashboard)/kits/nouveau/page.tsx
@@ -14,14 +14,14 @@ export default function NewKitPage() {
     <RoleGuard requiredRole={UserRole.DEV}>
       <div className="bg-background min-h-screen w-full py-8">
         <div className="container mx-auto px-6">
-          {/* Header épuré */}
+          {/* Header with gradient accent */}
           <div className="mb-8">
             <div className="mb-6 flex items-center gap-4">
-              <div className="bg-primary/10 border-primary/20 flex h-12 w-12 items-center justify-center rounded-xl border">
-                <Package2 className="text-primary h-6 w-6" />
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-[#30C1BD] to-[#30C1BD]/70 shadow-lg shadow-[#30C1BD]/20">
+                <Package2 className="h-6 w-6 text-white" />
               </div>
               <div>
-                <h1 className="text-foreground text-3xl font-bold">Nouveau kit</h1>
+                <h1 className="text-foreground text-3xl font-bold tracking-tight">Nouveau kit</h1>
                 <p className="text-muted-foreground">
                   Créez un kit personnalisé en sélectionnant vos produits
                 </p>
@@ -31,8 +31,8 @@ export default function NewKitPage() {
             {/* Navigation breadcrumb */}
             <div className="text-muted-foreground flex items-center gap-2 text-sm">
               <span>Kits</span>
-              <span>•</span>
-              <span className="text-primary">Nouveau kit</span>
+              <span className="text-[#30C1BD]">/</span>
+              <span className="font-medium text-[#30C1BD]">Nouveau kit</span>
             </div>
           </div>
 

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -3,20 +3,39 @@ import { UserRole } from '@/lib/types/user'
 import { ProjectsListWrapper } from '@/components/projects/projects-list-wrapper'
 import { CreateProjectButton } from '@/components/projects/create-project-button'
 import { FolderOpen } from 'lucide-react'
-import { getProjects } from '@/lib/db'
-import { getCurrentUserId } from '@/lib/auth-helpers'
+import { getProjects, prisma } from '@/lib/db'
+import { getUserSession } from '@/lib/auth-helpers'
+import { isAdminOrDev } from '@/lib/utils/roles'
 
 // Disable all caching for this page
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-export default async function ProjectsPage() {
-  // Get current user ID from session
-  const userId = await getCurrentUserId()
+interface ProjectsPageProps {
+  searchParams: Promise<{ userId?: string }>
+}
 
-  // Fetch projects directly from database using Prisma
-  // If no userId, return empty array (user not authenticated)
-  const projects = userId ? await getProjects(userId) : []
+export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
+  const session = await getUserSession()
+  const currentUserId = session?.user?.id || null
+
+  const params = await searchParams
+  const requestedUserId = params.userId
+
+  // Resolve role from DB (session may not include it server-side)
+  let canViewOtherUsers = false
+  if (currentUserId) {
+    const dbUser = await prisma.user.findUnique({
+      where: { id: currentUserId },
+      select: { role: true },
+    })
+    const role = (dbUser?.role as UserRole | undefined) ?? UserRole.USER
+    canViewOtherUsers = isAdminOrDev(role)
+  }
+
+  const targetUserId = requestedUserId && canViewOtherUsers ? requestedUserId : currentUserId
+
+  const projects = targetUserId ? await getProjects(targetUserId) : []
 
   return (
     <RoleGuard requiredRole={UserRole.USER}>
@@ -38,7 +57,10 @@ export default async function ProjectsPage() {
           </div>
 
           {/* Client wrapper for projects list */}
-          <ProjectsListWrapper initialProjects={projects} />
+          <ProjectsListWrapper
+            initialProjects={projects}
+            selectedUserId={targetUserId || undefined}
+          />
         </div>
       </div>
     </RoleGuard>

--- a/src/app/api/kits/[id]/route.test.ts
+++ b/src/app/api/kits/[id]/route.test.ts
@@ -77,6 +77,7 @@ describe('PUT /api/kits/[id]', () => {
   const updateData = {
     nom: 'Updated Kit',
     style: 'modern',
+    surfaceM2: 25,
     products: [{ productId: 'p1', quantite: 3 }],
   }
 

--- a/src/app/api/kits/route.test.ts
+++ b/src/app/api/kits/route.test.ts
@@ -76,6 +76,7 @@ describe('POST /api/kits', () => {
   const validKit = {
     nom: 'New Kit',
     style: 'modern',
+    surfaceM2: 25,
     products: [{ productId: 'p1', quantite: 2 }],
   }
 
@@ -138,6 +139,7 @@ describe('POST /api/kits', () => {
     const kitWithDupes = {
       nom: 'Kit Dupes',
       style: 'modern',
+      surfaceM2: 30,
       products: [
         { productId: 'p1', quantite: 2 },
         { productId: 'p1', quantite: 3 },

--- a/src/components/kits/form-sections/kit-form-actions.tsx
+++ b/src/components/kits/form-sections/kit-form-actions.tsx
@@ -2,46 +2,97 @@
 
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Save, RotateCcw, X, ArrowRight, ArrowLeft } from 'lucide-react'
 
 interface KitFormActionsProps {
   isLoading: boolean
   kitId?: string
   onReset: () => void
+  currentStep: number
+  onNextStep: () => void
+  onPreviousStep: () => void
 }
 
-export function KitFormActions({ isLoading, kitId, onReset }: KitFormActionsProps) {
+export function KitFormActions({
+  isLoading,
+  kitId,
+  onReset,
+  currentStep,
+  onNextStep,
+  onPreviousStep,
+}: KitFormActionsProps) {
   const router = useRouter()
 
   return (
-    <div className="flex flex-col justify-end gap-4 border-t pt-6 sm:flex-row">
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => router.back()}
-        disabled={isLoading}
-        className="order-3 sm:order-1"
-      >
-        Annuler
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={onReset}
-        disabled={isLoading}
-        className="order-2"
-      >
-        Réinitialiser
-      </Button>
-      <Button
-        type="submit"
-        disabled={isLoading}
-        data-testid="kit-submit"
-        className="order-1 cursor-pointer bg-[#30C1BD] text-white hover:bg-[#30C1BD]/80 sm:order-3"
-      >
-        {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-        {kitId ? 'Mettre à jour le kit' : 'Créer le kit'}
-      </Button>
+    <div className="fixed inset-x-0 bottom-0 z-50 border-t border-gray-200/80 bg-white/80 backdrop-blur-lg">
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+        {/* Left side */}
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => router.back()}
+            disabled={isLoading}
+            className="gap-2 text-gray-600 hover:text-gray-900"
+          >
+            <X className="h-4 w-4" />
+            Annuler
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onReset}
+            disabled={isLoading}
+            className="gap-2"
+          >
+            <RotateCcw className="h-4 w-4" />
+            Réinitialiser
+          </Button>
+        </div>
+
+        {/* Right side */}
+        <div className="flex items-center gap-3">
+          {currentStep === 2 && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onPreviousStep}
+              disabled={isLoading}
+              className="gap-2"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Précédent
+            </Button>
+          )}
+
+          {currentStep === 1 && (
+            <Button
+              type="button"
+              onClick={onNextStep}
+              className="gap-2 bg-[#30C1BD] px-6 text-white shadow-lg shadow-[#30C1BD]/25 hover:bg-[#30C1BD]/80"
+            >
+              Suivant
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          )}
+
+          {currentStep === 2 && (
+            <Button
+              type="submit"
+              disabled={isLoading}
+              data-testid="kit-submit"
+              className="gap-2 bg-[#30C1BD] px-6 text-white shadow-lg shadow-[#30C1BD]/25 hover:bg-[#30C1BD]/80"
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4" />
+              )}
+              {kitId ? 'Mettre à jour le kit' : 'Créer le kit'}
+            </Button>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/kits/form-sections/kit-general-info-section.tsx
+++ b/src/components/kits/form-sections/kit-general-info-section.tsx
@@ -4,8 +4,7 @@ import { Control, FieldErrors, Controller } from 'react-hook-form'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
-import { Info } from 'lucide-react'
+import { Tag, Palette, Ruler, Info, FileText } from 'lucide-react'
 import { KitFormData } from '@/lib/schemas/kit'
 
 interface KitGeneralInfoSectionProps {
@@ -15,75 +14,86 @@ interface KitGeneralInfoSectionProps {
 
 export function KitGeneralInfoSection({ control, errors }: KitGeneralInfoSectionProps) {
   return (
-    <AccordionItem value="general" className="rounded-lg border">
-      <AccordionTrigger className="px-6 py-4 hover:no-underline">
-        <div className="flex items-center gap-3">
-          <div className="rounded-lg bg-[#30C1BD]/10 p-2">
-            <Info className="h-5 w-5 text-[#30C1BD]" />
-          </div>
-          <div className="text-left">
-            <h3 className="font-semibold">Informations générales</h3>
-            <p className="text-sm text-gray-500">Nom, style et description du kit</p>
-          </div>
+    <div className="overflow-hidden rounded-xl border border-[#30C1BD]/20 bg-white shadow-sm">
+      {/* Header bar with gradient */}
+      <div className="flex items-center gap-3 bg-gradient-to-r from-[#30C1BD]/10 to-[#30C1BD]/5 px-6 py-4">
+        <div className="rounded-lg bg-[#30C1BD]/15 p-2">
+          <Info className="h-5 w-5 text-[#30C1BD]" />
         </div>
-      </AccordionTrigger>
-      <AccordionContent className="px-6 pb-6">
-        <div className="space-y-6">
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor="nom" className="text-sm font-medium">
-                Nom du kit *
-              </Label>
-              <Controller
-                name="nom"
-                control={control}
-                render={({ field }) => (
+        <div>
+          <h3 className="font-semibold text-gray-900">Informations générales</h3>
+          <p className="text-sm text-gray-500">Nom, style et description du kit</p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="space-y-6 px-6 py-6">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          {/* Nom */}
+          <div className="space-y-2">
+            <Label htmlFor="nom" className="flex items-center gap-1.5 text-sm font-medium">
+              Nom du kit <span className="text-red-500">*</span>
+            </Label>
+            <Controller
+              name="nom"
+              control={control}
+              render={({ field }) => (
+                <div className="relative">
+                  <Tag className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
                   <Input
                     {...field}
                     id="nom"
                     placeholder="Ex: Kit Solaire Résidentiel"
-                    className={`transition-colors ${
+                    className={`pl-10 transition-colors ${
                       errors.nom
                         ? 'border-red-500 focus:border-red-500'
                         : 'focus:border-[#30C1BD] focus:ring-[#30C1BD]'
                     }`}
                   />
-                )}
-              />
-              {errors.nom && <p className="text-sm text-red-500">{errors.nom.message}</p>}
-            </div>
+                </div>
+              )}
+            />
+            {errors.nom && <p className="text-sm text-red-500">{errors.nom.message}</p>}
+          </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="style" className="text-sm font-medium">
-                Style *
-              </Label>
-              <Controller
-                name="style"
-                control={control}
-                render={({ field }) => (
+          {/* Style */}
+          <div className="space-y-2">
+            <Label htmlFor="style" className="flex items-center gap-1.5 text-sm font-medium">
+              Style <span className="text-red-500">*</span>
+            </Label>
+            <Controller
+              name="style"
+              control={control}
+              render={({ field }) => (
+                <div className="relative">
+                  <Palette className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
                   <Input
                     {...field}
                     id="style"
-                    placeholder="Ex: Résidentiel, Commercial, Industriel"
-                    className={`transition-colors ${
+                    placeholder="Ex: Résidentiel, Commercial"
+                    className={`pl-10 transition-colors ${
                       errors.style
                         ? 'border-red-500 focus:border-red-500'
                         : 'focus:border-[#30C1BD] focus:ring-[#30C1BD]'
                     }`}
                   />
-                )}
-              />
-              {errors.style && <p className="text-sm text-red-500">{errors.style.message}</p>}
-            </div>
+                </div>
+              )}
+            />
+            {errors.style && <p className="text-sm text-red-500">{errors.style.message}</p>}
+          </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="surfaceM2" className="text-sm font-medium">
-                Surface (m²) <span className="text-red-500">*</span>
-              </Label>
-              <Controller
-                name="surfaceM2"
-                control={control}
-                render={({ field }) => (
+          {/* Surface */}
+          <div className="space-y-2">
+            <Label htmlFor="surfaceM2" className="flex items-center gap-1.5 text-sm font-medium">
+              Surface (m²) <span className="text-red-500">*</span>
+            </Label>
+            <Controller
+              name="surfaceM2"
+              control={control}
+              render={({ field }) => (
+                <div className="relative">
+                  <Ruler className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
                   <Input
                     {...field}
                     id="surfaceM2"
@@ -96,47 +106,47 @@ export function KitGeneralInfoSection({ control, errors }: KitGeneralInfoSection
                       const value = e.target.value
                       field.onChange(value === '' ? undefined : parseFloat(value))
                     }}
-                    className={`transition-colors ${
+                    className={`pl-10 transition-colors ${
                       errors.surfaceM2
                         ? 'border-red-500 focus:border-red-500'
                         : 'focus:border-[#30C1BD] focus:ring-[#30C1BD]'
                     }`}
                   />
-                )}
-              />
-              {errors.surfaceM2 && (
-                <p className="text-sm text-red-500">{errors.surfaceM2.message}</p>
-              )}
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="description" className="text-sm font-medium">
-              Description
-            </Label>
-            <Controller
-              name="description"
-              control={control}
-              render={({ field }) => (
-                <Textarea
-                  {...field}
-                  id="description"
-                  placeholder="Description détaillée du kit et de ses avantages..."
-                  rows={4}
-                  className={`resize-none transition-colors ${
-                    errors.description
-                      ? 'border-red-500 focus:border-red-500'
-                      : 'focus:border-[#30C1BD] focus:ring-[#30C1BD]'
-                  }`}
-                />
+                </div>
               )}
             />
-            {errors.description && (
-              <p className="text-sm text-red-500">{errors.description.message}</p>
-            )}
+            {errors.surfaceM2 && <p className="text-sm text-red-500">{errors.surfaceM2.message}</p>}
           </div>
         </div>
-      </AccordionContent>
-    </AccordionItem>
+
+        {/* Description */}
+        <div className="space-y-2">
+          <Label htmlFor="description" className="flex items-center gap-1.5 text-sm font-medium">
+            <FileText className="h-3.5 w-3.5 text-gray-400" />
+            Description
+          </Label>
+          <Controller
+            name="description"
+            control={control}
+            render={({ field }) => (
+              <Textarea
+                {...field}
+                id="description"
+                placeholder="Description détaillée du kit et de ses avantages..."
+                rows={4}
+                className={`resize-none transition-colors ${
+                  errors.description
+                    ? 'border-red-500 focus:border-red-500'
+                    : 'focus:border-[#30C1BD] focus:ring-[#30C1BD]'
+                }`}
+              />
+            )}
+          />
+          {errors.description && (
+            <p className="text-sm text-red-500">{errors.description.message}</p>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/components/kits/form-sections/kit-general-info-section.tsx
+++ b/src/components/kits/form-sections/kit-general-info-section.tsx
@@ -78,7 +78,7 @@ export function KitGeneralInfoSection({ control, errors }: KitGeneralInfoSection
 
             <div className="space-y-2">
               <Label htmlFor="surfaceM2" className="text-sm font-medium">
-                Surface (m²)
+                Surface (m²) <span className="text-red-500">*</span>
               </Label>
               <Controller
                 name="surfaceM2"

--- a/src/components/kits/form-sections/kit-products-section.tsx
+++ b/src/components/kits/form-sections/kit-products-section.tsx
@@ -5,7 +5,6 @@ import { Control, useFieldArray, FieldErrors, useWatch } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -209,406 +208,330 @@ export function KitProductsSection({ control, errors, onError }: KitProductsSect
   }, [watchedProducts, products])
 
   return (
-    <AccordionItem value="products" className="rounded-lg border">
-      <AccordionTrigger className="px-6 py-4 hover:no-underline">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 rounded-lg p-2">
-            <Package className="text-primary h-5 w-5" />
-          </div>
-          <div className="text-left">
-            <h3 className="font-semibold">Produits du kit</h3>
-            <p className="text-muted-foreground text-sm">
-              Sélectionnez les produits et leurs quantités
-            </p>
-          </div>
-          {fields.length > 0 && (
-            <Badge variant="secondary" className="ml-auto">
-              {fields.length} produit{fields.length > 1 ? 's' : ''}
-            </Badge>
-          )}
+    <div className="overflow-hidden rounded-xl border border-[#30C1BD]/20 bg-white shadow-sm">
+      {/* Header bar with gradient */}
+      <div className="flex items-center gap-3 bg-gradient-to-r from-[#30C1BD]/10 to-[#30C1BD]/5 px-6 py-4">
+        <div className="rounded-lg bg-[#30C1BD]/15 p-2">
+          <Package className="h-5 w-5 text-[#30C1BD]" />
         </div>
-      </AccordionTrigger>
-      <AccordionContent className="px-6 pb-6">
-        <div className="space-y-6">
-          {/* Selected Products List */}
-          {fields.length > 0 && (
-            <div className="space-y-3">
-              <h4 className="text-muted-foreground text-sm font-medium">Produits sélectionnés</h4>
-              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                {fields.map((field, index) => {
-                  const selectedProduct = getSelectedProduct(field.productId)
-                  if (!selectedProduct) return null
+        <div className="flex-1">
+          <h3 className="font-semibold text-gray-900">Produits du kit</h3>
+          <p className="text-sm text-gray-500">Sélectionnez les produits et leurs quantités</p>
+        </div>
+        {fields.length > 0 && (
+          <Badge variant="secondary" className="bg-[#30C1BD]/10 text-[#30C1BD]">
+            {fields.length} produit{fields.length > 1 ? 's' : ''}
+          </Badge>
+        )}
+      </div>
 
-                  return (
-                    <Card key={field.id} className="overflow-hidden">
-                      <CardContent className="p-4">
-                        <div className="flex gap-3">
-                          {/* Product Image */}
-                          <div className="from-muted/30 to-muted/50 relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-md bg-gradient-to-br">
-                            {selectedProduct.image ? (
-                              <img
-                                src={selectedProduct.image}
-                                alt={selectedProduct.nom}
-                                className="h-full w-full object-cover"
-                              />
-                            ) : (
-                              <div className="flex h-full items-center justify-center">
-                                <Package className="text-muted-foreground/40 h-6 w-6" />
-                              </div>
-                            )}
-                          </div>
+      {/* Content */}
+      <div className="space-y-6 px-6 py-6">
+        {/* Selected Products List */}
+        {fields.length > 0 && (
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-gray-500">Produits sélectionnés</h4>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {fields.map((field, index) => {
+                const selectedProduct = getSelectedProduct(field.productId)
+                if (!selectedProduct) return null
 
-                          {/* Product Info */}
-                          <div className="min-w-0 flex-1 space-y-2">
-                            <div>
-                              <h5 className="truncate text-sm font-semibold">
-                                {selectedProduct.nom}
-                              </h5>
-                              <Badge variant="secondary" className="text-xs">
-                                {selectedProduct.reference}
-                              </Badge>
-                            </div>
+                const pricingAchat = getProductPricing(selectedProduct, 'achat', '1an')
+                const pricingLocation1An = getProductPricing(selectedProduct, 'location', '1an')
 
-                            {/* Quantity Controls */}
-                            <div className="flex items-center gap-2">
-                              <Label className="text-muted-foreground text-xs">Quantité:</Label>
-                              <div className="flex items-center gap-1">
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="icon"
-                                  className="h-6 w-6"
-                                  onClick={() => updateQuantity(index, -1)}
-                                  disabled={field.quantite <= 1}
-                                >
-                                  <Minus className="h-3 w-3" />
-                                </Button>
-                                <Input
-                                  type="number"
-                                  min="1"
-                                  value={field.quantite}
-                                  onChange={(e) => {
-                                    const value = Number(e.target.value) || 1
-                                    const current = watchedProducts?.[index]
-                                    if (!current) return
-                                    update(index, {
-                                      ...current,
-                                      quantite: Math.max(1, value),
-                                    })
-                                  }}
-                                  className="h-6 w-12 p-0 text-center text-xs"
-                                />
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="icon"
-                                  className="h-6 w-6"
-                                  onClick={() => updateQuantity(index, 1)}
-                                >
-                                  <Plus className="h-3 w-3" />
-                                </Button>
-                              </div>
-                            </div>
+                return (
+                  <Card
+                    key={field.id}
+                    className="group relative overflow-hidden rounded-xl border border-gray-200 transition-shadow hover:shadow-md"
+                  >
+                    {/* Delete Button - top right */}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => remove(index)}
+                      className="absolute top-2 right-2 z-10 h-7 w-7 rounded-full bg-white/80 text-red-500 opacity-0 shadow-sm backdrop-blur-sm transition-opacity group-hover:opacity-100 hover:bg-red-50 hover:text-red-700"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
 
-                            {/* Price - Achat & Location */}
-                            <div className="space-y-1.5">
-                              {(() => {
-                                const pricingAchat = getProductPricing(
-                                  selectedProduct,
-                                  'achat',
-                                  '1an',
-                                )
-                                const pricingLocation1An = getProductPricing(
-                                  selectedProduct,
-                                  'location',
-                                  '1an',
-                                )
-                                const pricingLocation2Ans = getProductPricing(
-                                  selectedProduct,
-                                  'location',
-                                  '2ans',
-                                )
-                                const pricingLocation3Ans = getProductPricing(
-                                  selectedProduct,
-                                  'location',
-                                  '3ans',
-                                )
+                    {/* Product Image */}
+                    <div className="relative h-36 w-full overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100">
+                      {selectedProduct.image ? (
+                        <img
+                          src={selectedProduct.image}
+                          alt={selectedProduct.nom}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center">
+                          <Package className="h-10 w-10 text-gray-300" />
+                        </div>
+                      )}
+                    </div>
 
-                                return (
-                                  <>
-                                    {/* Prix d'achat - toujours affiché */}
-                                    <div className="flex items-center gap-1 text-xs">
-                                      <ShoppingCart className="text-primary h-3 w-3" />
-                                      <span className="text-muted-foreground">Achat:</span>
-                                      {pricingAchat.prixVente && pricingAchat.prixVente > 0 ? (
-                                        <span className="text-primary font-semibold">
-                                          {formatPrice(pricingAchat.prixVente * field.quantite)}
-                                        </span>
-                                      ) : (
-                                        <span className="text-xs text-orange-600 italic">
-                                          Non renseigné
-                                        </span>
-                                      )}
-                                    </div>
+                    {/* Product Info */}
+                    <CardContent className="space-y-3 p-4">
+                      <div>
+                        <h5 className="truncate text-sm font-semibold text-gray-900">
+                          {selectedProduct.nom}
+                        </h5>
+                        <Badge variant="secondary" className="mt-1 text-xs">
+                          {selectedProduct.reference}
+                        </Badge>
+                      </div>
 
-                                    {/* Prix de location - 3 périodes */}
-                                    <div className="border-primary/20 space-y-0.5 border-l-2 pl-4">
-                                      <div className="flex items-center gap-1 text-xs">
-                                        <Home className="text-primary h-3 w-3" />
-                                        <span className="text-muted-foreground">
-                                          Loc. 1an /mois:
-                                        </span>
-                                        {pricingLocation1An.prixVente &&
-                                        pricingLocation1An.prixVente > 0 ? (
-                                          <span className="text-primary font-semibold">
-                                            {formatPrice(
-                                              pricingLocation1An.prixVente * field.quantite,
-                                            )}
-                                          </span>
-                                        ) : (
-                                          <span className="text-xs text-orange-600 italic">
-                                            Non renseigné
-                                          </span>
-                                        )}
-                                      </div>
+                      {/* Pricing */}
+                      <div className="space-y-1 text-xs">
+                        <div className="flex items-center justify-between">
+                          <span className="flex items-center gap-1 text-gray-500">
+                            <Home className="h-3 w-3 text-[#30C1BD]" />
+                            Location /mois
+                          </span>
+                          {pricingLocation1An.prixVente && pricingLocation1An.prixVente > 0 ? (
+                            <span className="font-semibold text-[#30C1BD]">
+                              {formatPrice(pricingLocation1An.prixVente * field.quantite)}
+                            </span>
+                          ) : (
+                            <span className="text-orange-500 italic">N/A</span>
+                          )}
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <span className="flex items-center gap-1 text-gray-500">
+                            <ShoppingCart className="h-3 w-3 text-[#30C1BD]" />
+                            Achat
+                          </span>
+                          {pricingAchat.prixVente && pricingAchat.prixVente > 0 ? (
+                            <span className="font-semibold text-[#30C1BD]">
+                              {formatPrice(pricingAchat.prixVente * field.quantite)}
+                            </span>
+                          ) : (
+                            <span className="text-orange-500 italic">N/A</span>
+                          )}
+                        </div>
+                      </div>
 
-                                      <div className="flex items-center gap-1 text-xs">
-                                        <Home className="text-primary h-3 w-3" />
-                                        <span className="text-muted-foreground">
-                                          Loc. 2ans /mois:
-                                        </span>
-                                        {pricingLocation2Ans.prixVente &&
-                                        pricingLocation2Ans.prixVente > 0 ? (
-                                          <span className="text-primary font-semibold">
-                                            {formatPrice(
-                                              pricingLocation2Ans.prixVente * field.quantite,
-                                            )}
-                                          </span>
-                                        ) : (
-                                          <span className="text-xs text-orange-600 italic">
-                                            Non renseigné
-                                          </span>
-                                        )}
-                                      </div>
-
-                                      <div className="flex items-center gap-1 text-xs">
-                                        <Home className="text-primary h-3 w-3" />
-                                        <span className="text-muted-foreground">
-                                          Loc. 3ans /mois:
-                                        </span>
-                                        {pricingLocation3Ans.prixVente &&
-                                        pricingLocation3Ans.prixVente > 0 ? (
-                                          <span className="text-primary font-semibold">
-                                            {formatPrice(
-                                              pricingLocation3Ans.prixVente * field.quantite,
-                                            )}
-                                          </span>
-                                        ) : (
-                                          <span className="text-xs text-orange-600 italic">
-                                            Non renseigné
-                                          </span>
-                                        )}
-                                      </div>
-                                    </div>
-                                  </>
-                                )
-                              })()}
-                            </div>
-                          </div>
-
-                          {/* Delete Button */}
+                      {/* Quantity Controls */}
+                      <div className="flex items-center justify-between border-t border-gray-100 pt-3">
+                        <Label className="text-xs font-medium text-gray-500">Quantité</Label>
+                        <div className="flex items-center gap-1.5">
                           <Button
                             type="button"
-                            variant="ghost"
+                            variant="outline"
                             size="icon"
-                            onClick={() => remove(index)}
-                            className="h-8 w-8 text-red-600 hover:bg-red-50 hover:text-red-700"
+                            className="h-7 w-7 rounded-full"
+                            onClick={() => updateQuantity(index, -1)}
+                            disabled={field.quantite <= 1}
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Minus className="h-3 w-3" />
+                          </Button>
+                          <Input
+                            type="number"
+                            min="1"
+                            value={field.quantite}
+                            onChange={(e) => {
+                              const value = Number(e.target.value) || 1
+                              const current = watchedProducts?.[index]
+                              if (!current) return
+                              update(index, {
+                                ...current,
+                                quantite: Math.max(1, value),
+                              })
+                            }}
+                            className="h-7 w-12 rounded-lg p-0 text-center text-sm font-semibold"
+                          />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            className="h-7 w-7 rounded-full"
+                            onClick={() => updateQuantity(index, 1)}
+                          >
+                            <Plus className="h-3 w-3" />
                           </Button>
                         </div>
-                      </CardContent>
-                    </Card>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* Product Selection Grid */}
-          {showProductSelection && !isLoadingProducts && (
-            <div className="border-t pt-6">
-              <ProductSelectionGrid
-                products={products}
-                productQuantities={productQuantities}
-                onQuantityChange={handleQuantityChange}
-              />
-            </div>
-          )}
-
-          {/* Add Product Button */}
-          {!showProductSelection && (
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setShowProductSelection(true)}
-              className="hover:border-primary hover:text-primary w-full border-2 border-dashed"
-              disabled={isLoadingProducts}
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              {fields.length === 0 ? 'Ajouter des produits' : 'Ajouter un autre produit'}
-            </Button>
-          )}
-
-          {errors.products && <p className="text-sm text-red-500">{errors.products.message}</p>}
-
-          {/* Summary Card with Mode Selection */}
-          {fields.length > 0 && (
-            <div className="from-primary/5 to-primary/10 border-primary/20 rounded-xl border bg-gradient-to-br p-5 shadow-sm">
-              <div className="mb-4 flex items-center gap-2">
-                <div className="bg-primary/10 rounded-lg p-2">
-                  <Calculator className="text-primary h-5 w-5" />
-                </div>
-                <h4 className="text-primary text-lg font-semibold">Récapitulatif du kit</h4>
-              </div>
-
-              <Tabs defaultValue="achat" className="w-full">
-                <TabsList className="mb-4 grid w-full grid-cols-2">
-                  <TabsTrigger value="achat" className="gap-2">
-                    <ShoppingCart className="h-4 w-4" />
-                    Achat
-                  </TabsTrigger>
-                  <TabsTrigger value="location" className="gap-2">
-                    <Home className="h-4 w-4" />
-                    Location
-                  </TabsTrigger>
-                </TabsList>
-
-                {/* Achat Tab */}
-                <TabsContent value="achat" className="space-y-4">
-                  {/* Prix Achat */}
-                  <div className="border-primary/10 rounded-lg border bg-white/60 p-6">
-                    <div className="flex flex-col items-center justify-center gap-2">
-                      <p className="text-muted-foreground text-sm font-medium">
-                        Prix d&apos;achat total
-                      </p>
-                      <p className="text-primary text-3xl font-bold">
-                        {formatPrice(totals.totalAchat1An)}
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Surface totale */}
-                  {totals.totalSurface > 0 && (
-                    <div className="border-primary/10 rounded-lg border bg-white/60 p-4">
-                      <div className="flex items-center justify-center gap-2">
-                        <Square className="text-primary h-5 w-5" />
-                        <p className="text-muted-foreground text-sm font-medium">
-                          Surface totale utilisée:
-                        </p>
-                        <p className="text-primary text-2xl font-bold">
-                          {totals.totalSurface.toFixed(2)} m²
-                        </p>
                       </div>
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Product Selection Grid */}
+        {showProductSelection && !isLoadingProducts && (
+          <div className="border-t pt-6">
+            <ProductSelectionGrid
+              products={products}
+              productQuantities={productQuantities}
+              onQuantityChange={handleQuantityChange}
+            />
+          </div>
+        )}
+
+        {/* Add Product Button */}
+        {!showProductSelection && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setShowProductSelection(true)}
+            className="w-full border-2 border-dashed border-[#30C1BD]/40 text-[#30C1BD] hover:border-[#30C1BD] hover:bg-[#30C1BD]/5 hover:text-[#30C1BD]"
+            disabled={isLoadingProducts}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            {fields.length === 0 ? 'Ajouter des produits' : 'Ajouter un autre produit'}
+          </Button>
+        )}
+
+        {errors.products && <p className="text-sm text-red-500">{errors.products.message}</p>}
+
+        {/* Summary Card with Mode Selection */}
+        {fields.length > 0 && (
+          <div className="rounded-xl border border-[#30C1BD]/20 bg-gradient-to-br from-[#30C1BD]/5 to-[#30C1BD]/10 p-5 shadow-sm">
+            <div className="mb-4 flex items-center gap-2">
+              <div className="rounded-lg bg-[#30C1BD]/15 p-2">
+                <Calculator className="h-5 w-5 text-[#30C1BD]" />
+              </div>
+              <h4 className="text-lg font-semibold text-[#30C1BD]">Récapitulatif du kit</h4>
+            </div>
+
+            <Tabs defaultValue="location" className="w-full">
+              <TabsList className="mb-4 grid w-full grid-cols-2">
+                <TabsTrigger value="location" className="gap-2">
+                  <Home className="h-4 w-4" />
+                  Location
+                </TabsTrigger>
+                <TabsTrigger value="achat" className="gap-2">
+                  <ShoppingCart className="h-4 w-4" />
+                  Achat
+                </TabsTrigger>
+              </TabsList>
+
+              {/* Location Tab */}
+              <TabsContent value="location" className="space-y-4">
+                {/* Prix Location */}
+                <div className="rounded-lg border border-[#30C1BD]/10 bg-white/60 p-4">
+                  <div className="grid grid-cols-3 gap-4">
+                    <div className="text-center">
+                      <p className="text-muted-foreground mb-1 text-xs font-medium">
+                        Prix 1 an /mois
+                      </p>
+                      <p className="text-xl font-bold text-[#30C1BD]">
+                        {formatPrice(totals.totalLocation1An)}
+                      </p>
                     </div>
-                  )}
-
-                  {/* Impact Environnemental - Achat : MASQUÉ (demande client) */}
-                  {/* L'impact environnemental n'est affiché que pour la location */}
-                </TabsContent>
-
-                {/* Location Tab */}
-                <TabsContent value="location" className="space-y-4">
-                  {/* Prix Location */}
-                  <div className="border-primary/10 rounded-lg border bg-white/60 p-4">
-                    <div className="grid grid-cols-3 gap-4">
+                    {totals.totalLocation2Ans > 0 && (
                       <div className="text-center">
                         <p className="text-muted-foreground mb-1 text-xs font-medium">
-                          Prix 1 an /mois
+                          Prix 2 ans /mois
                         </p>
-                        <p className="text-primary text-xl font-bold">
-                          {formatPrice(totals.totalLocation1An)}
+                        <p className="text-xl font-bold text-[#30C1BD]">
+                          {formatPrice(totals.totalLocation2Ans)}
                         </p>
                       </div>
-                      {totals.totalLocation2Ans > 0 && (
-                        <div className="text-center">
-                          <p className="text-muted-foreground mb-1 text-xs font-medium">
-                            Prix 2 ans /mois
-                          </p>
-                          <p className="text-primary text-xl font-bold">
-                            {formatPrice(totals.totalLocation2Ans)}
-                          </p>
-                        </div>
-                      )}
-                      {totals.totalLocation3Ans > 0 && (
-                        <div className="text-center">
-                          <p className="text-muted-foreground mb-1 text-xs font-medium">
-                            Prix 3 ans /mois
-                          </p>
-                          <p className="text-primary text-xl font-bold">
-                            {formatPrice(totals.totalLocation3Ans)}
-                          </p>
-                        </div>
-                      )}
+                    )}
+                    {totals.totalLocation3Ans > 0 && (
+                      <div className="text-center">
+                        <p className="text-muted-foreground mb-1 text-xs font-medium">
+                          Prix 3 ans /mois
+                        </p>
+                        <p className="text-xl font-bold text-[#30C1BD]">
+                          {formatPrice(totals.totalLocation3Ans)}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Surface totale */}
+                {totals.totalSurface > 0 && (
+                  <div className="rounded-lg border border-[#30C1BD]/10 bg-white/60 p-4">
+                    <div className="flex items-center justify-center gap-2">
+                      <Square className="h-5 w-5 text-[#30C1BD]" />
+                      <p className="text-muted-foreground text-sm font-medium">
+                        Surface totale utilisée:
+                      </p>
+                      <p className="text-2xl font-bold text-[#30C1BD]">
+                        {totals.totalSurface.toFixed(2)} m²
+                      </p>
                     </div>
                   </div>
+                )}
 
-                  {/* Surface totale */}
-                  {totals.totalSurface > 0 && (
-                    <div className="border-primary/10 rounded-lg border bg-white/60 p-4">
-                      <div className="flex items-center justify-center gap-2">
-                        <Square className="text-primary h-5 w-5" />
-                        <p className="text-muted-foreground text-sm font-medium">
-                          Surface totale utilisée:
-                        </p>
-                        <p className="text-primary text-2xl font-bold">
-                          {totals.totalSurface.toFixed(2)} m²
-                        </p>
-                      </div>
+                {/* Impact Environnemental - Location */}
+                <div className="rounded-lg border border-emerald-200/50 bg-emerald-50/60 p-4">
+                  <div className="mb-3 flex items-center gap-2">
+                    <Leaf className="h-4 w-4 text-emerald-600" />
+                    <span className="text-sm font-semibold text-emerald-900">
+                      Impact environnemental (CO₂ économisé)
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                    <div className="rounded bg-white/60 p-2">
+                      <span className="text-muted-foreground block text-xs">CO₂:</span>
+                      <p className="font-bold" style={{ color: '#FE9E58' }}>
+                        {totals.totalCO2Location.toFixed(2)} kg
+                      </p>
                     </div>
-                  )}
-
-                  {/* Impact Environnemental - Location */}
-                  <div className="rounded-lg border border-emerald-200/50 bg-emerald-50/60 p-4">
-                    <div className="mb-3 flex items-center gap-2">
-                      <Leaf className="h-4 w-4 text-emerald-600" />
-                      <span className="text-sm font-semibold text-emerald-900">
-                        Impact environnemental (CO₂ économisé)
-                      </span>
+                    <div className="rounded bg-white/60 p-2">
+                      <span className="text-muted-foreground block text-xs">Ressources:</span>
+                      <p className="font-bold" style={{ color: '#FE5858' }}>
+                        {totals.totalRessourcesLocation.toFixed(2)} MJ
+                      </p>
                     </div>
-                    <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
-                      <div className="rounded bg-white/60 p-2">
-                        <span className="text-muted-foreground block text-xs">CO₂:</span>
-                        <p className="font-bold" style={{ color: '#FE9E58' }}>
-                          {totals.totalCO2Location.toFixed(2)} kg
-                        </p>
-                      </div>
-                      <div className="rounded bg-white/60 p-2">
-                        <span className="text-muted-foreground block text-xs">Ressources:</span>
-                        <p className="font-bold" style={{ color: '#FE5858' }}>
-                          {totals.totalRessourcesLocation.toFixed(2)} MJ
-                        </p>
-                      </div>
-                      <div className="rounded bg-white/60 p-2">
-                        <span className="text-muted-foreground block text-xs">Acidification:</span>
-                        <p className="font-bold" style={{ color: '#55D789' }}>
-                          {totals.totalAcidificationLocation.toFixed(4)} MOL
-                        </p>
-                      </div>
-                      <div className="rounded bg-white/60 p-2">
-                        <span className="text-muted-foreground block text-xs">Eutrophisation:</span>
-                        <p className="font-bold" style={{ color: '#55D789' }}>
-                          {totals.totalEutrophisationLocation.toFixed(4)} kg P
-                        </p>
-                      </div>
+                    <div className="rounded bg-white/60 p-2">
+                      <span className="text-muted-foreground block text-xs">Acidification:</span>
+                      <p className="font-bold" style={{ color: '#55D789' }}>
+                        {totals.totalAcidificationLocation.toFixed(4)} MOL
+                      </p>
+                    </div>
+                    <div className="rounded bg-white/60 p-2">
+                      <span className="text-muted-foreground block text-xs">Eutrophisation:</span>
+                      <p className="font-bold" style={{ color: '#55D789' }}>
+                        {totals.totalEutrophisationLocation.toFixed(4)} kg P
+                      </p>
                     </div>
                   </div>
-                </TabsContent>
-              </Tabs>
-            </div>
-          )}
-        </div>
-      </AccordionContent>
-    </AccordionItem>
+                </div>
+              </TabsContent>
+
+              {/* Achat Tab */}
+              <TabsContent value="achat" className="space-y-4">
+                {/* Prix Achat */}
+                <div className="rounded-lg border border-[#30C1BD]/10 bg-white/60 p-6">
+                  <div className="flex flex-col items-center justify-center gap-2">
+                    <p className="text-muted-foreground text-sm font-medium">
+                      Prix d&apos;achat total
+                    </p>
+                    <p className="text-3xl font-bold text-[#30C1BD]">
+                      {formatPrice(totals.totalAchat1An)}
+                    </p>
+                  </div>
+                </div>
+
+                {/* Surface totale */}
+                {totals.totalSurface > 0 && (
+                  <div className="rounded-lg border border-[#30C1BD]/10 bg-white/60 p-4">
+                    <div className="flex items-center justify-center gap-2">
+                      <Square className="h-5 w-5 text-[#30C1BD]" />
+                      <p className="text-muted-foreground text-sm font-medium">
+                        Surface totale utilisée:
+                      </p>
+                      <p className="text-2xl font-bold text-[#30C1BD]">
+                        {totals.totalSurface.toFixed(2)} m²
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Impact Environnemental - Achat : MASQUÉ (demande client) */}
+                {/* L'impact environnemental n'est affiché que pour la location */}
+              </TabsContent>
+            </Tabs>
+          </div>
+        )}
+      </div>
+    </div>
   )
 }

--- a/src/components/kits/kit-card.tsx
+++ b/src/components/kits/kit-card.tsx
@@ -114,17 +114,8 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
     return total
   }, [selectedMode, kit.kitProducts])
 
-  // Calculate total surface area from products
-  const totalProductsSurface = useMemo(() => {
-    let total = 0
-    kit.kitProducts?.forEach((kitProduct) => {
-      const { product, quantite } = kitProduct
-      if (product && product.surfaceM2) {
-        total += product.surfaceM2 * quantite
-      }
-    })
-    return total
-  }, [kit.kitProducts])
+  // Surface always comes from kit.surfaceM2
+  const totalProductsSurface = kit.surfaceM2 ?? 0
 
   const handleDelete = async () => {
     if (!onDelete) {

--- a/src/components/kits/kit-card.tsx
+++ b/src/components/kits/kit-card.tsx
@@ -47,7 +47,7 @@ interface KitCardProps {
 
 export function KitCard({ kit, onDelete }: KitCardProps) {
   const router = useRouter()
-  const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('achat')
+  const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('location')
 
   // Calculate total price based on selected mode and period
   const totalPriceAchat = useMemo(() => {
@@ -205,17 +205,6 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
         {/* Sélecteur de mode */}
         <div className="mb-4 flex gap-1">
           <Button
-            variant={selectedMode === 'achat' ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => setSelectedMode('achat')}
-            className={`h-7 flex-1 px-2 text-xs ${
-              selectedMode === 'achat' ? 'bg-[#30C1BD] hover:bg-[#30C1BD]/90' : ''
-            }`}
-          >
-            <ShoppingCart className="mr-1 h-3 w-3" />
-            Achat
-          </Button>
-          <Button
             variant={selectedMode === 'location' ? 'default' : 'outline'}
             size="sm"
             onClick={() => setSelectedMode('location')}
@@ -225,6 +214,17 @@ export function KitCard({ kit, onDelete }: KitCardProps) {
           >
             <Home className="mr-1 h-3 w-3" />
             Location
+          </Button>
+          <Button
+            variant={selectedMode === 'achat' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setSelectedMode('achat')}
+            className={`h-7 flex-1 px-2 text-xs ${
+              selectedMode === 'achat' ? 'bg-[#30C1BD] hover:bg-[#30C1BD]/90' : ''
+            }`}
+          >
+            <ShoppingCart className="mr-1 h-3 w-3" />
+            Achat
           </Button>
         </div>
 

--- a/src/components/kits/kit-form.tsx
+++ b/src/components/kits/kit-form.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { useZodForm } from '@/lib/forms'
 import { kitSchema, type KitFormData } from '@/lib/schemas/kit'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Accordion } from '@/components/ui/accordion'
 import { useSession } from '@/lib/auth-client'
 import { logger } from '@/lib/logger'
+import { Info, Package, Check } from 'lucide-react'
 
 // Import des sections
 import { KitGeneralInfoSection } from './form-sections/kit-general-info-section'
@@ -19,17 +19,21 @@ interface KitFormProps {
   readonly kitId?: string
 }
 
+const STEP_1_FIELDS = ['nom', 'style', 'surfaceM2'] as const
+
 export function KitForm({ initialData, kitId }: KitFormProps) {
   const router = useRouter()
   const { data: session } = useSession()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [currentStep, setCurrentStep] = useState(1)
 
   const {
     handleSubmit,
     formState: { errors },
     reset,
     control,
+    trigger,
   } = useZodForm(kitSchema, {
     defaultValues: {
       products: [],
@@ -49,6 +53,24 @@ export function KitForm({ initialData, kitId }: KitFormProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kitId])
+
+  const handleNextStep = useCallback(async () => {
+    const isValid = await trigger(STEP_1_FIELDS as unknown as (keyof KitFormData)[])
+    if (isValid) {
+      setCurrentStep(2)
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+  }, [trigger])
+
+  const handlePreviousStep = useCallback(() => {
+    setCurrentStep(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
+
+  const handleReset = useCallback(() => {
+    reset()
+    setCurrentStep(1)
+  }, [reset])
 
   const onSubmit = async (data: KitFormData) => {
     if (!session?.user) {
@@ -117,20 +139,89 @@ export function KitForm({ initialData, kitId }: KitFormProps) {
 
   return (
     <div className="mx-auto max-w-4xl">
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      {/* Step Indicator */}
+      <div className="mb-8 flex items-center justify-center gap-0">
+        {/* Step 1 */}
+        <button
+          type="button"
+          onClick={() => {
+            if (currentStep > 1) handlePreviousStep()
+          }}
+          className="flex items-center gap-2.5 transition-opacity hover:opacity-80"
+        >
+          <div
+            className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold shadow-md transition-colors ${
+              currentStep >= 1
+                ? 'bg-[#30C1BD] text-white shadow-[#30C1BD]/25'
+                : 'bg-gray-200 text-gray-500 shadow-gray-200/25'
+            }`}
+          >
+            {currentStep > 1 ? <Check className="h-4 w-4" /> : '1'}
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Info className={`h-4 w-4 ${currentStep >= 1 ? 'text-[#30C1BD]' : 'text-gray-400'}`} />
+            <span
+              className={`text-sm font-semibold ${currentStep >= 1 ? 'text-[#30C1BD]' : 'text-gray-400'}`}
+            >
+              Informations
+            </span>
+          </div>
+        </button>
+
+        {/* Connector */}
+        <div
+          className={`mx-4 h-px w-16 transition-colors ${
+            currentStep >= 2 ? 'bg-[#30C1BD]' : 'bg-gradient-to-r from-[#30C1BD] to-gray-200'
+          }`}
+        />
+
+        {/* Step 2 */}
+        <div className="flex items-center gap-2.5">
+          <div
+            className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold shadow-md transition-colors ${
+              currentStep >= 2
+                ? 'bg-[#30C1BD] text-white shadow-[#30C1BD]/25'
+                : 'bg-gray-200 text-gray-500 shadow-gray-200/25'
+            }`}
+          >
+            2
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Package
+              className={`h-4 w-4 ${currentStep >= 2 ? 'text-[#30C1BD]' : 'text-gray-400'}`}
+            />
+            <span
+              className={`text-sm font-semibold ${currentStep >= 2 ? 'text-[#30C1BD]' : 'text-gray-400'}`}
+            >
+              Produits
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 pb-24">
         {error && (
           <Alert className="border-red-200 bg-red-50">
             <AlertDescription className="text-red-800">{error}</AlertDescription>
           </Alert>
         )}
 
-        <Accordion type="multiple" defaultValue={['general', 'products']} className="space-y-4">
-          <KitGeneralInfoSection control={control} errors={errors} />
+        {/* Step 1: General Info */}
+        {currentStep === 1 && <KitGeneralInfoSection control={control} errors={errors} />}
 
+        {/* Step 2: Products */}
+        {currentStep === 2 && (
           <KitProductsSection control={control} errors={errors} onError={handleError} />
-        </Accordion>
+        )}
 
-        <KitFormActions isLoading={isLoading} kitId={kitId} onReset={reset} />
+        <KitFormActions
+          isLoading={isLoading}
+          kitId={kitId}
+          onReset={handleReset}
+          currentStep={currentStep}
+          onNextStep={handleNextStep}
+          onPreviousStep={handlePreviousStep}
+        />
       </form>
     </div>
   )

--- a/src/components/products/form-sections/pricing-environmental-section.tsx
+++ b/src/components/products/form-sections/pricing-environmental-section.tsx
@@ -24,7 +24,7 @@ export function PricingEnvironmentalSection({
   setValue,
   errors,
 }: PricingEnvironmentalSectionProps) {
-  const [activeMode, setActiveMode] = useState<PurchaseRentalMode>('achat')
+  const [activeMode, setActiveMode] = useState<PurchaseRentalMode>('location')
 
   // Watch des valeurs pour les calculs automatiques
   const watchedValues = {
@@ -790,24 +790,6 @@ export function PricingEnvironmentalSection({
               <TabsList className="inline-flex h-12 min-w-full items-center justify-center rounded-2xl border border-gray-200/50 bg-gradient-to-r from-gray-50 via-white to-gray-50 p-1 text-gray-500 shadow-lg backdrop-blur-sm lg:min-w-0">
                 <div className="flex w-full space-x-1 lg:w-auto">
                   <TabsTrigger
-                    value="achat"
-                    className="group relative inline-flex min-w-0 flex-1 items-center justify-center rounded-xl px-4 py-2 text-sm font-medium whitespace-nowrap transition-all duration-300 hover:bg-white/60 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-[#30C1BD] focus-visible:ring-offset-1 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border data-[state=active]:border-gray-200/80 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-lg lg:min-w-max lg:flex-initial"
-                  >
-                    <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-[#30C1BD]/0 to-blue-500/0 opacity-0 transition-opacity duration-300 data-[state=active]:opacity-5"></div>
-                    <ShoppingCart
-                      className={`mr-2 h-4 w-4 transition-colors duration-200 ${
-                        activeMode === 'achat' ? 'text-[#30C1BD]' : ''
-                      }`}
-                    />
-                    <span className="text-sm font-medium">Achat</span>
-                    <div
-                      className={`absolute bottom-0 left-1/2 h-0.5 -translate-x-1/2 transform rounded-full bg-gradient-to-r from-[#30C1BD] to-blue-500 transition-all duration-300 ${
-                        activeMode === 'achat' ? 'w-8' : 'w-0'
-                      }`}
-                    ></div>
-                  </TabsTrigger>
-
-                  <TabsTrigger
                     value="location"
                     className="group relative inline-flex min-w-0 flex-1 items-center justify-center rounded-xl px-4 py-2 text-sm font-medium whitespace-nowrap transition-all duration-300 hover:bg-white/60 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-[#30C1BD] focus-visible:ring-offset-1 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border data-[state=active]:border-gray-200/80 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-lg lg:min-w-max lg:flex-initial"
                   >
@@ -821,6 +803,24 @@ export function PricingEnvironmentalSection({
                     <div
                       className={`absolute bottom-0 left-1/2 h-0.5 -translate-x-1/2 transform rounded-full bg-gradient-to-r from-[#30C1BD] to-blue-500 transition-all duration-300 ${
                         activeMode === 'location' ? 'w-8' : 'w-0'
+                      }`}
+                    ></div>
+                  </TabsTrigger>
+
+                  <TabsTrigger
+                    value="achat"
+                    className="group relative inline-flex min-w-0 flex-1 items-center justify-center rounded-xl px-4 py-2 text-sm font-medium whitespace-nowrap transition-all duration-300 hover:bg-white/60 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-[#30C1BD] focus-visible:ring-offset-1 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border data-[state=active]:border-gray-200/80 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-lg lg:min-w-max lg:flex-initial"
+                  >
+                    <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-[#30C1BD]/0 to-blue-500/0 opacity-0 transition-opacity duration-300 data-[state=active]:opacity-5"></div>
+                    <ShoppingCart
+                      className={`mr-2 h-4 w-4 transition-colors duration-200 ${
+                        activeMode === 'achat' ? 'text-[#30C1BD]' : ''
+                      }`}
+                    />
+                    <span className="text-sm font-medium">Achat</span>
+                    <div
+                      className={`absolute bottom-0 left-1/2 h-0.5 -translate-x-1/2 transform rounded-full bg-gradient-to-r from-[#30C1BD] to-blue-500 transition-all duration-300 ${
+                        activeMode === 'achat' ? 'w-8' : 'w-0'
                       }`}
                     ></div>
                   </TabsTrigger>

--- a/src/components/projects/available-kit-card.tsx
+++ b/src/components/projects/available-kit-card.tsx
@@ -43,7 +43,7 @@ export function AvailableKitCard({
   onQuantityChange,
   onToggleExpand,
 }: AvailableKitCardProps) {
-  const kitImpact = calculateKitImpact(kit.kitProducts, selectedMode)
+  const kitImpact = calculateKitImpact(kit.kitProducts, selectedMode, kit.surfaceM2)
   const kitPrice = calculateKitPrice(
     kit.kitProducts,
     selectedMode,

--- a/src/components/projects/kits-tab.tsx
+++ b/src/components/projects/kits-tab.tsx
@@ -29,7 +29,7 @@ interface KitsTabProps {
  * @returns Tab with catalog browsing and project kit management
  */
 export function KitsTab({ projectKits, onAddKits, onUpdateQuantity, onRemoveKit }: KitsTabProps) {
-  const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('achat')
+  const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('location')
   const [showAddSection, setShowAddSection] = useState(false)
   const [availableKits, setAvailableKits] = useState<AvailableKit[]>([])
   const [searchTerm, setSearchTerm] = useState('')

--- a/src/components/projects/pricing-detailed-analysis.tsx
+++ b/src/components/projects/pricing-detailed-analysis.tsx
@@ -41,7 +41,7 @@ interface PricingDetailedAnalysisProps {
  */
 export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProps) {
   const canViewCosts = useCanViewCosts()
-  const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('achat')
+  const [selectedMode, setSelectedMode] = useState<PurchaseRentalMode>('location')
   const [selectedPeriod, setSelectedPeriod] = useState<ProductPeriod>('1an')
   const [selectedHorizon, setSelectedHorizon] = useState(5)
 
@@ -76,17 +76,6 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
           </div>
           <div className="flex space-x-3 rounded-2xl bg-gray-100 p-1">
             <Button
-              variant={selectedMode === 'achat' ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setSelectedMode('achat')}
-              className={`flex items-center gap-2 ${
-                selectedMode === 'achat' ? 'bg-[#30C1BD] hover:bg-[#30C1BD]/90' : ''
-              }`}
-            >
-              <ShoppingCart className="h-4 w-4" />
-              Achat
-            </Button>
-            <Button
               variant={selectedMode === 'location' ? 'default' : 'outline'}
               size="sm"
               onClick={() => setSelectedMode('location')}
@@ -96,6 +85,17 @@ export function PricingDetailedAnalysis({ project }: PricingDetailedAnalysisProp
             >
               <Home className="h-4 w-4" />
               Location
+            </Button>
+            <Button
+              variant={selectedMode === 'achat' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setSelectedMode('achat')}
+              className={`flex items-center gap-2 ${
+                selectedMode === 'achat' ? 'bg-[#30C1BD] hover:bg-[#30C1BD]/90' : ''
+              }`}
+            >
+              <ShoppingCart className="h-4 w-4" />
+              Achat
             </Button>
           </div>
         </div>

--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -108,7 +108,7 @@ const formatDate = (date: Date | string): string => {
  */
 export function ProjectCard({ project, onDelete }: ProjectCardProps) {
   // Local state for pricing mode
-  const [pricingMode, setPricingMode] = useState<ProjectCardPricingMode>('achat')
+  const [pricingMode, setPricingMode] = useState<ProjectCardPricingMode>('location')
 
   // Memoized status config
   const statusConfig = useMemo(() => {
@@ -163,18 +163,18 @@ export function ProjectCard({ project, onDelete }: ProjectCardProps) {
         >
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger
-              value="achat"
-              className="data-[state=active]:bg-[#30C1BD] data-[state=active]:text-white"
-            >
-              <ShoppingCart className="mr-1.5 h-3.5 w-3.5" />
-              <span className="text-xs font-medium">Achat</span>
-            </TabsTrigger>
-            <TabsTrigger
               value="location"
               className="data-[state=active]:bg-[#30C1BD] data-[state=active]:text-white"
             >
               <Home className="mr-1.5 h-3.5 w-3.5" />
               <span className="text-xs font-medium">Location 3 ans</span>
+            </TabsTrigger>
+            <TabsTrigger
+              value="achat"
+              className="data-[state=active]:bg-[#30C1BD] data-[state=active]:text-white"
+            >
+              <ShoppingCart className="mr-1.5 h-3.5 w-3.5" />
+              <span className="text-xs font-medium">Achat</span>
             </TabsTrigger>
           </TabsList>
         </Tabs>

--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -54,7 +54,7 @@ const TAB_TRIGGER_CLASS =
  */
 export function ProjectDetail({ project, onProjectUpdate, refreshProject }: ProjectDetailProps) {
   const [isEditProjectDialogOpen, setIsEditProjectDialogOpen] = useState(false)
-  const [pricingMode, setPricingMode] = useState<PurchaseRentalMode>('achat')
+  const [pricingMode, setPricingMode] = useState<PurchaseRentalMode>('location')
   const [pricingPeriod, setPricingPeriod] = useState<ProductPeriod>('1an')
   const router = useRouter()
   const searchParams = useSearchParams()

--- a/src/components/projects/project-kit-card.tsx
+++ b/src/components/projects/project-kit-card.tsx
@@ -70,7 +70,7 @@ export function ProjectKitCard({
     )
   }
 
-  const kitImpact = calculateKitImpact(kit.kitProducts, selectedMode)
+  const kitImpact = calculateKitImpact(kit.kitProducts, selectedMode, kit.surfaceM2)
   const kitPrice = calculateKitPrice(kit.kitProducts, selectedMode)
   const totalPrice = kitPrice * projectKit.quantite
   const totalImpact = {
@@ -259,20 +259,22 @@ export function ProjectKitCard({
         </CardHeader>
 
         <CardContent className="relative z-10 space-y-4">
-          <div className="grid grid-cols-1 gap-3">
-            <motion.div
-              whileHover={{ y: -2, scale: 1.02 }}
-              className="rounded-xl border border-teal-100 bg-gradient-to-br from-teal-50 to-blue-50 p-4 text-center shadow-sm transition-all duration-200 hover:shadow-md"
-            >
-              <div className="mx-auto mb-2 flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-teal-100 to-blue-100">
-                <Target className="h-4 w-4 text-teal-600" />
-              </div>
-              <div className="mb-1 text-sm font-bold text-teal-900">
-                {totalImpact.surface.toFixed(1)}
-              </div>
-              <div className="text-xs text-teal-700">m² - Surface totale</div>
-            </motion.div>
-          </div>
+          {totalImpact.surface > 0 && (
+            <div className="grid grid-cols-1 gap-3">
+              <motion.div
+                whileHover={{ y: -2, scale: 1.02 }}
+                className="rounded-xl border border-teal-100 bg-gradient-to-br from-teal-50 to-blue-50 p-4 text-center shadow-sm transition-all duration-200 hover:shadow-md"
+              >
+                <div className="mx-auto mb-2 flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-teal-100 to-blue-100">
+                  <Target className="h-4 w-4 text-teal-600" />
+                </div>
+                <div className="mb-1 text-sm font-bold text-teal-900">
+                  {totalImpact.surface.toFixed(1)}
+                </div>
+                <div className="text-xs text-teal-700">m² - Surface totale</div>
+              </motion.div>
+            </div>
+          )}
 
           {selectedMode === 'location' && (
             <>

--- a/src/components/projects/projects-list-wrapper.tsx
+++ b/src/components/projects/projects-list-wrapper.tsx
@@ -6,18 +6,36 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { FolderOpen } from 'lucide-react'
 import { type Project } from '@/lib/types/project'
+import { UserSelector } from '@/components/projects/user-selector'
 import { logger } from '@/lib/logger'
 
 interface ProjectsListWrapperProps {
   initialProjects: Project[]
+  selectedUserId?: string
 }
 
-function ProjectsListContent({ initialProjects }: ProjectsListWrapperProps) {
+function ProjectsListContent({ initialProjects, selectedUserId }: ProjectsListWrapperProps) {
   const [projects, setProjects] = useState<Project[]>(initialProjects)
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     setProjects(initialProjects)
   }, [initialProjects])
+
+  const handleUserChange = useCallback(async (userId: string) => {
+    setLoading(true)
+    try {
+      const response = await fetch(`/api/projects?userId=${encodeURIComponent(userId)}`)
+      if (response.ok) {
+        const data = await response.json()
+        setProjects(data)
+      }
+    } catch (error) {
+      logger.error('[ProjectsListWrapper] Error fetching projects for user', { error })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
 
   const handleDelete = useCallback(
     async (projectId: string) => {
@@ -30,7 +48,6 @@ function ProjectsListContent({ initialProjects }: ProjectsListWrapperProps) {
           throw new Error('Erreur lors de la suppression du projet')
         }
 
-        // Remove project from local state without refetch
         const updatedProjects = projects.filter((p) => p.id !== projectId)
         setProjects(updatedProjects)
       } catch (err) {
@@ -40,28 +57,35 @@ function ProjectsListContent({ initialProjects }: ProjectsListWrapperProps) {
     [projects],
   )
 
-  if (projects.length === 0) {
-    return (
-      <div className="py-12 text-center">
-        <div className="bg-muted/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl">
-          <FolderOpen className="text-muted-foreground h-8 w-8" />
-        </div>
-        <h3 className="text-foreground mb-2 text-lg font-semibold">Aucun projet trouvé</h3>
-        <p className="text-muted-foreground">Commencez par créer votre premier projet</p>
-      </div>
-    )
-  }
-
   return (
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {projects.map((project) => (
-        <ProjectCard key={project.id} project={project} onDelete={handleDelete} />
-      ))}
+    <div className="space-y-6">
+      <UserSelector onUserChange={handleUserChange} selectedUserId={selectedUserId} />
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <ProjectCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : projects.length === 0 ? (
+        <div className="py-12 text-center">
+          <div className="bg-muted/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl">
+            <FolderOpen className="text-muted-foreground h-8 w-8" />
+          </div>
+          <h3 className="text-foreground mb-2 text-lg font-semibold">Aucun projet trouvé</h3>
+          <p className="text-muted-foreground">Commencez par créer votre premier projet</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} onDelete={handleDelete} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
 
-// Loading skeleton component
 function ProjectCardSkeleton() {
   return (
     <Card>
@@ -96,7 +120,6 @@ function ProjectCardSkeleton() {
   )
 }
 
-// Wrapper component with Suspense boundary
 export function ProjectsListWrapper(props: ProjectsListWrapperProps) {
   return (
     <Suspense

--- a/src/components/projects/shared/purchase-rental-mode-selector.tsx
+++ b/src/components/projects/shared/purchase-rental-mode-selector.tsx
@@ -23,19 +23,6 @@ export function PurchaseRentalModeSelector({
       <span className="text-sm font-medium text-gray-700">Mode :</span>
       <div className="flex space-x-1 rounded-2xl bg-gray-100 p-1">
         <Button
-          variant={mode === 'achat' ? 'default' : 'ghost'}
-          size="sm"
-          onClick={() => onModeChange('achat')}
-          className={`flex items-center gap-2 transition-all duration-200 ${
-            mode === 'achat'
-              ? 'bg-[#30C1BD] text-white shadow-sm hover:bg-[#30C1BD]/90'
-              : 'hover:bg-white/60'
-          }`}
-        >
-          <ShoppingCart className="h-4 w-4" />
-          Achat
-        </Button>
-        <Button
           variant={mode === 'location' ? 'default' : 'ghost'}
           size="sm"
           onClick={() => onModeChange('location')}
@@ -47,6 +34,19 @@ export function PurchaseRentalModeSelector({
         >
           <Home className="h-4 w-4" />
           Location
+        </Button>
+        <Button
+          variant={mode === 'achat' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => onModeChange('achat')}
+          className={`flex items-center gap-2 transition-all duration-200 ${
+            mode === 'achat'
+              ? 'bg-[#30C1BD] text-white shadow-sm hover:bg-[#30C1BD]/90'
+              : 'hover:bg-white/60'
+          }`}
+        >
+          <ShoppingCart className="h-4 w-4" />
+          Achat
         </Button>
       </div>
     </div>

--- a/src/components/projects/user-selector.tsx
+++ b/src/components/projects/user-selector.tsx
@@ -1,19 +1,16 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Input } from '@/components/ui/input'
 import { RoleGuard } from '@/components/auth/role-guard'
 import { UserRole } from '@/lib/types/user'
-import { User } from 'lucide-react'
+import { User, Check, ChevronsUpDown, Search } from 'lucide-react'
 import { useSession } from '@/lib/auth-client'
 import { useRouter } from 'next/navigation'
+import { useDebounce } from '@/hooks/use-debounce'
 import { logger } from '@/lib/logger'
+import { cn } from '@/lib/utils'
 
 interface SimpleUser {
   id: string
@@ -29,55 +26,70 @@ interface UserSelectorProps {
 export function UserSelector({ onUserChange, selectedUserId }: UserSelectorProps) {
   const [users, setUsers] = useState<SimpleUser[]>([])
   const [loading, setLoading] = useState(true)
+  const [open, setOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
   const { data: session } = useSession()
   const router = useRouter()
+  const inputRef = useRef<HTMLInputElement>(null)
 
-  // Utiliser l'userId passé en props ou l'utilisateur connecté
   const currentUserId = selectedUserId || session?.user?.id || ''
+  const debouncedSearch = useDebounce(searchQuery, 300)
 
   useEffect(() => {
+    async function fetchUsers() {
+      try {
+        const response = await fetch('/api/users')
+        if (response.ok) {
+          const data = await response.json()
+          setUsers(data)
+        }
+      } catch (error) {
+        logger.error('Error loading users', { error })
+      } finally {
+        setLoading(false)
+      }
+    }
     fetchUsers()
   }, [])
 
-  const fetchUsers = async () => {
-    try {
-      const response = await fetch('/api/users')
-      if (response.ok) {
-        const data = await response.json()
-        setUsers(data)
+  const filteredUsers = useMemo(() => {
+    if (!debouncedSearch) return users
+    const query = debouncedSearch.toLowerCase()
+    return users.filter(
+      (u) => u.name.toLowerCase().includes(query) || u.email.toLowerCase().includes(query),
+    )
+  }, [users, debouncedSearch])
+
+  const selectedUser = useMemo(
+    () => users.find((u) => u.id === currentUserId),
+    [users, currentUserId],
+  )
+
+  const handleSelect = useCallback(
+    (userId: string) => {
+      setOpen(false)
+      setSearchQuery('')
+
+      if (typeof window !== 'undefined') {
+        const url = new URL(window.location.href)
+        if (userId === session?.user?.id) {
+          url.searchParams.delete('userId')
+        } else {
+          url.searchParams.set('userId', userId)
+        }
+        router.push(url.pathname + url.search)
       }
-    } catch (error) {
-      logger.error('Error loading users', { error })
-    } finally {
-      setLoading(false)
-    }
-  }
 
-  const handleUserChange = (userId: string) => {
-    // Mettre à jour l'URL
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href)
-      if (userId === session?.user?.id) {
-        // Si c'est l'utilisateur connecté, supprimer le paramètre
-        url.searchParams.delete('userId')
-      } else {
-        url.searchParams.set('userId', userId)
-      }
-      router.push(url.pathname + url.search)
-    }
+      onUserChange(userId)
+    },
+    [session?.user?.id, router, onUserChange],
+  )
 
-    // Notifier le parent
-    onUserChange(userId)
-  }
-
-  const getCurrentUserName = () => {
-    const user = users.find((u) => u.id === currentUserId)
-    if (user) {
-      return user.name
-    }
-    // Si pas trouvé dans la liste, utiliser les infos de session
-    return session?.user?.name || session?.user?.email || 'Utilisateur actuel'
-  }
+  const displayLabel = loading
+    ? 'Chargement...'
+    : selectedUser
+      ? selectedUser.name
+      : session?.user?.name || 'Utilisateur actuel'
 
   return (
     <RoleGuard requiredRole={UserRole.DEV}>
@@ -86,23 +98,66 @@ export function UserSelector({ onUserChange, selectedUserId }: UserSelectorProps
           <User className="h-4 w-4" />
           <span>Projets de :</span>
         </div>
-        <Select value={currentUserId} onValueChange={handleUserChange} disabled={loading}>
-          <SelectTrigger className="w-64">
-            <SelectValue placeholder={loading ? 'Chargement...' : 'Sélectionner un utilisateur'}>
-              {loading ? 'Chargement...' : getCurrentUserName()}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            {users.map((user) => (
-              <SelectItem key={user.id} value={user.id}>
-                <div className="flex flex-col">
-                  <span className="font-medium">{user.name}</span>
-                  <span className="text-muted-foreground text-xs">{user.email}</span>
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={loading}
+              className={cn(
+                'border-input bg-background ring-offset-background flex h-10 w-72 items-center justify-between rounded-md border px-3 py-2 text-sm',
+                'placeholder:text-muted-foreground focus:ring-ring focus:ring-2 focus:ring-offset-2 focus:outline-none',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+            >
+              <span className="truncate">{displayLabel}</span>
+              <ChevronsUpDown className="text-muted-foreground ml-2 h-4 w-4 shrink-0" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-0" align="start">
+            <div className="border-b p-2">
+              <div className="flex items-center gap-2 px-1">
+                <Search className="text-muted-foreground h-4 w-4 shrink-0" />
+                <Input
+                  ref={inputRef}
+                  placeholder="Rechercher un utilisateur..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="h-8 border-0 p-0 shadow-none focus-visible:ring-0"
+                />
+              </div>
+            </div>
+            <div className="max-h-60 overflow-y-auto p-1">
+              {filteredUsers.length === 0 ? (
+                <div className="text-muted-foreground py-4 text-center text-sm">
+                  Aucun utilisateur trouvé
                 </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+              ) : (
+                filteredUsers.map((user) => (
+                  <button
+                    key={user.id}
+                    type="button"
+                    onClick={() => handleSelect(user.id)}
+                    className={cn(
+                      'hover:bg-accent flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                      user.id === currentUserId && 'bg-accent',
+                    )}
+                  >
+                    <Check
+                      className={cn(
+                        'h-4 w-4 shrink-0',
+                        user.id === currentUserId ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-medium">{user.name}</div>
+                      <div className="text-muted-foreground truncate text-xs">{user.email}</div>
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
       </div>
     </RoleGuard>
   )

--- a/src/lib/schemas/kit.ts
+++ b/src/lib/schemas/kit.ts
@@ -7,19 +7,18 @@ export const kitProductSchema = z.object({
 
 export const kitSchema = z.object({
   nom: z
-    .string()
+    .string({ error: 'Le nom est requis' })
     .min(1, 'Le nom est requis')
     .max(100, 'Le nom ne peut pas dépasser 100 caractères'),
   style: z
-    .string()
+    .string({ error: 'Le style est requis' })
     .min(1, 'Le style est requis')
     .max(50, 'Le style ne peut pas dépasser 50 caractères'),
   description: z.string().optional(),
   surfaceM2: z
-    .number()
-    .min(0, 'La surface doit être positive')
-    .max(10000, 'La surface ne peut pas dépasser 10 000 m²')
-    .optional(),
+    .number({ error: 'La surface est requise' })
+    .positive({ error: 'La surface doit être supérieure à 0' })
+    .max(10000, { error: 'La surface ne peut pas dépasser 10 000 m²' }),
   products: z.array(kitProductSchema).min(1, 'Au moins un produit est requis'),
 })
 

--- a/src/lib/services/project.service.test.ts
+++ b/src/lib/services/project.service.test.ts
@@ -38,6 +38,7 @@ const makeProjectKit = (overrides: Partial<ProjectKit> = {}): ProjectKit => ({
     id: 'kit-1',
     nom: 'Kit 1',
     style: 'modern',
+    surfaceM2: 15,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
     createdById: 'user-1',
@@ -89,7 +90,7 @@ describe('calculateProjectTotals', () => {
     })
   })
 
-  it('calculates totals from kit products', () => {
+  it('calculates surface from kit.surfaceM2 multiplied by projectKit quantity', () => {
     const project = makeProject({
       projectKits: [
         makeProjectKit({
@@ -98,6 +99,7 @@ describe('calculateProjectTotals', () => {
             id: 'kit-1',
             nom: 'Kit 1',
             style: 'modern',
+            surfaceM2: 20,
             createdAt: '2026-01-01T00:00:00.000Z',
             updatedAt: '2026-01-01T00:00:00.000Z',
             createdById: 'user-1',
@@ -112,8 +114,8 @@ describe('calculateProjectTotals', () => {
 
     // prixVente=200, kitProduct.quantite=3, projectKit.quantite=2 => ceilPrice(200*3*2)=1200
     expect(result.totalPrix).toBe(ceilPrice(200 * 3 * 2))
-    // surface = product.surfaceM2(5) * kitProduct.quantite(3) * projectKit.quantite(2) = 30
-    expect(result.totalSurface).toBe(30)
+    // surface = kit.surfaceM2(20) * projectKit.quantite(2) = 40
+    expect(result.totalSurface).toBe(40)
     // rechauffement=10, kitProduct.quantite=3, projectKit.quantite=2 => 10*3*2=60
     expect(result.totalImpact.rechauffementClimatique).toBe(60)
     expect(result.totalImpact.epuisementRessources).toBe(120)
@@ -133,7 +135,7 @@ describe('calculateProjectTotals', () => {
     expect(result.totalSurface).toBe(42)
   })
 
-  it('calculates surface from kit products when override is disabled', () => {
+  it('uses kit.surfaceM2 when override is disabled', () => {
     const project = makeProject({
       surfaceOverride: false,
       projectKits: [
@@ -143,16 +145,12 @@ describe('calculateProjectTotals', () => {
             id: 'kit-1',
             nom: 'Kit 1',
             style: 'modern',
+            surfaceM2: 10,
             createdAt: '2026-01-01T00:00:00.000Z',
             updatedAt: '2026-01-01T00:00:00.000Z',
             createdById: 'user-1',
             updatedById: 'user-1',
-            kitProducts: [
-              makeKitProduct({
-                quantite: 2,
-                product: makeProduct({ surfaceM2: 5 }) as KitProduct['product'],
-              }),
-            ],
+            kitProducts: [makeKitProduct({ quantite: 2 })],
           },
         }),
       ],
@@ -160,8 +158,31 @@ describe('calculateProjectTotals', () => {
 
     const result = calculateProjectTotals(project)
 
-    // surface = product.surfaceM2(5) * kitProduct.quantite(2) * projectKit.quantite(3) = 30
+    // surface = kit.surfaceM2(10) * projectKit.quantite(3) = 30
     expect(result.totalSurface).toBe(30)
+  })
+
+  it('handles kit with null surfaceM2 gracefully', () => {
+    const project = makeProject({
+      projectKits: [
+        makeProjectKit({
+          kit: {
+            id: 'kit-1',
+            nom: 'Kit 1',
+            style: 'modern',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            createdById: 'user-1',
+            updatedById: 'user-1',
+            kitProducts: [makeKitProduct()],
+          },
+        }),
+      ],
+    })
+
+    const result = calculateProjectTotals(project)
+
+    expect(result.totalSurface).toBe(0)
   })
 
   it('handles kit with null product gracefully', () => {
@@ -172,6 +193,7 @@ describe('calculateProjectTotals', () => {
             id: 'kit-1',
             nom: 'Kit 1',
             style: 'modern',
+            surfaceM2: 10,
             createdAt: '2026-01-01T00:00:00.000Z',
             updatedAt: '2026-01-01T00:00:00.000Z',
             createdById: 'user-1',
@@ -185,6 +207,7 @@ describe('calculateProjectTotals', () => {
     const result = calculateProjectTotals(project)
 
     expect(result.totalPrix).toBe(0)
+    expect(result.totalSurface).toBe(10)
   })
 
   it('aggregates totals across multiple kits with different products', () => {
@@ -216,6 +239,7 @@ describe('calculateProjectTotals', () => {
             id: 'kit-1',
             nom: 'Kit A',
             style: 'modern',
+            surfaceM2: 10,
             createdAt: '2026-01-01T00:00:00.000Z',
             updatedAt: '2026-01-01T00:00:00.000Z',
             createdById: 'user-1',
@@ -238,6 +262,7 @@ describe('calculateProjectTotals', () => {
             id: 'kit-2',
             nom: 'Kit B',
             style: 'classic',
+            surfaceM2: 25,
             createdAt: '2026-01-01T00:00:00.000Z',
             updatedAt: '2026-01-01T00:00:00.000Z',
             createdById: 'user-1',
@@ -260,8 +285,8 @@ describe('calculateProjectTotals', () => {
 
     // Kit A: ceilPrice(100*2*1)=200, Kit B: ceilPrice(300*1*3)=900 => 1100
     expect(result.totalPrix).toBe(ceilPrice(100 * 2 * 1) + ceilPrice(300 * 1 * 3))
-    // Surface: productA(5*2*1) + productB(5*1*3) = 10+15 = 25
-    expect(result.totalSurface).toBe(25)
+    // Surface: kitA.surfaceM2(10)*1 + kitB.surfaceM2(25)*3 = 10+75 = 85
+    expect(result.totalSurface).toBe(85)
     // Rechauffement: 5*2*1 + 15*1*3 = 10+45 = 55
     expect(result.totalImpact.rechauffementClimatique).toBe(55)
     // Epuisement: 10*2*1 + 30*1*3 = 20+90 = 110

--- a/src/lib/services/project.service.ts
+++ b/src/lib/services/project.service.ts
@@ -34,12 +34,9 @@ export function calculateProjectTotals(project: Project): ProjectTotals {
   } else {
     for (const projectKit of project.projectKits ?? []) {
       const kit = projectKit.kit
-      if (!kit?.kitProducts) continue
+      if (!kit) continue
 
-      const kitSurface = kit.kitProducts.reduce((acc, kp) => {
-        return acc + (kp.product?.surfaceM2 ?? 0) * kp.quantite
-      }, 0)
-      totalSurface += kitSurface * projectKit.quantite
+      totalSurface += (kit.surfaceM2 ?? 0) * projectKit.quantite
     }
   }
 

--- a/src/lib/utils/kit/calculations.test.ts
+++ b/src/lib/utils/kit/calculations.test.ts
@@ -65,7 +65,7 @@ describe('calculateKitPrice', () => {
 })
 
 describe('calculateKitImpact', () => {
-  it('returns all zeros for empty array', () => {
+  it('returns all zeros for empty array without kitSurfaceM2', () => {
     const impact = calculateKitImpact([], 'achat')
     expect(impact).toEqual({
       rechauffementClimatique: 0,
@@ -76,13 +76,18 @@ describe('calculateKitImpact', () => {
     })
   })
 
+  it('returns kitSurfaceM2 for empty array when provided', () => {
+    const impact = calculateKitImpact([], 'achat', 42)
+    expect(impact.surface).toBe(42)
+  })
+
   it('returns all zeros for null input', () => {
     const impact = calculateKitImpact(null as unknown as KitProduct[], 'achat')
     expect(impact.rechauffementClimatique).toBe(0)
     expect(impact.surface).toBe(0)
   })
 
-  it('aggregates impact for single product', () => {
+  it('uses kitSurfaceM2 instead of product surfaceM2', () => {
     const kitProducts = [
       makeKitProduct(2, {
         rechauffementClimatiqueAchat: 10,
@@ -92,15 +97,15 @@ describe('calculateKitImpact', () => {
         surfaceM2: 5,
       }),
     ]
-    const impact = calculateKitImpact(kitProducts, 'achat')
+    const impact = calculateKitImpact(kitProducts, 'achat', 25)
     expect(impact.rechauffementClimatique).toBe(20) // 10 * 2
     expect(impact.epuisementRessources).toBe(40) // 20 * 2
     expect(impact.acidification).toBe(60) // 30 * 2
     expect(impact.eutrophisation).toBe(80) // 40 * 2
-    expect(impact.surface).toBe(10) // 5 * 2
+    expect(impact.surface).toBe(25) // kit.surfaceM2, NOT product-level
   })
 
-  it('sums impact across multiple products', () => {
+  it('sums impact across multiple products but uses kit surface', () => {
     const kitProducts = [
       makeKitProduct(1, {
         rechauffementClimatiqueAchat: 10,
@@ -111,9 +116,9 @@ describe('calculateKitImpact', () => {
         surfaceM2: 2,
       }),
     ]
-    const impact = calculateKitImpact(kitProducts, 'achat')
+    const impact = calculateKitImpact(kitProducts, 'achat', 30)
     expect(impact.rechauffementClimatique).toBe(25) // 10*1 + 5*3
-    expect(impact.surface).toBe(11) // 5*1 + 2*3
+    expect(impact.surface).toBe(30) // kit.surfaceM2, NOT 5*1+2*3
   })
 
   it('skips products without product data', () => {
@@ -133,9 +138,15 @@ describe('calculateKitImpact', () => {
     expect(impact.rechauffementClimatique).toBe(0)
   })
 
-  it('defaults surfaceM2 to 0 when missing', () => {
+  it('defaults surface to 0 when kitSurfaceM2 is not provided', () => {
     const kitProducts = [makeKitProduct(1, { rechauffementClimatiqueAchat: 10 })]
     const impact = calculateKitImpact(kitProducts, 'achat')
+    expect(impact.surface).toBe(0)
+  })
+
+  it('defaults surface to 0 when kitSurfaceM2 is null', () => {
+    const kitProducts = [makeKitProduct(1, { rechauffementClimatiqueAchat: 10 })]
+    const impact = calculateKitImpact(kitProducts, 'achat', null)
     expect(impact.surface).toBe(0)
   })
 
@@ -148,8 +159,9 @@ describe('calculateKitImpact', () => {
         eutrophisationLocation: 32,
       }),
     ]
-    const impact = calculateKitImpact(kitProducts, 'location')
+    const impact = calculateKitImpact(kitProducts, 'location', 50)
     expect(impact.rechauffementClimatique).toBe(16) // 8 * 2
     expect(impact.epuisementRessources).toBe(32)
+    expect(impact.surface).toBe(50) // kit.surfaceM2
   })
 })

--- a/src/lib/utils/kit/calculations.ts
+++ b/src/lib/utils/kit/calculations.ts
@@ -20,19 +20,22 @@ const EMPTY_IMPACT: KitImpactResult = {
 
 /**
  * Aggregate environmental impact for all products in a kit.
+ * Surface always comes from kit.surfaceM2, never from individual products.
  * @param kitProducts - The list of products with quantities in the kit
  * @param mode - Purchase or rental mode
+ * @param kitSurfaceM2 - Kit-level surface in m²
  * @returns Aggregated environmental impact values and surface
  */
 export function calculateKitImpact(
   kitProducts: KitProduct[],
   mode: PurchaseRentalMode,
+  kitSurfaceM2?: number | null,
 ): KitImpactResult {
   if (!kitProducts || kitProducts.length === 0) {
-    return { ...EMPTY_IMPACT }
+    return { ...EMPTY_IMPACT, surface: kitSurfaceM2 ?? 0 }
   }
 
-  return kitProducts.reduce<KitImpactResult>(
+  const result = kitProducts.reduce<KitImpactResult>(
     (acc, kitProduct) => {
       const product = kitProduct.product
       if (!product) return acc
@@ -46,11 +49,15 @@ export function calculateKitImpact(
           acc.epuisementRessources + (impact.epuisementRessources || 0) * kitProduct.quantite,
         acidification: acc.acidification + (impact.acidification || 0) * kitProduct.quantite,
         eutrophisation: acc.eutrophisation + (impact.eutrophisation || 0) * kitProduct.quantite,
-        surface: acc.surface + (product.surfaceM2 || 0) * kitProduct.quantite,
+        surface: 0,
       }
     },
     { ...EMPTY_IMPACT },
   )
+
+  result.surface = kitSurfaceM2 ?? 0
+
+  return result
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add searchable user combobox on the projects page for admin/dev users to view any user's projects
- Replace basic Radix Select with Popover-based combobox featuring debounced search, name+email filtering, and checkmark selection
- Support server-side `?userId=` param with role-based access control (DB-resolved role)

## Related Issue

<!-- Link to Linear ticket or GitHub issue -->

## Changes

### User Selector (`src/components/projects/user-selector.tsx`)
- Replaced Radix `Select` with `Popover` + search `Input` combobox
- Added `useDebounce(300ms)` for search query filtering by name or email
- Checkmark indicator on selected user, auto-close on selection
- URL sync: sets/removes `?userId=` param based on selection

### Projects List Wrapper (`src/components/projects/projects-list-wrapper.tsx`)
- Added `selectedUserId` prop to pass initial selection
- Integrated `UserSelector` above the project grid (visible for DEV/ADMIN only via `RoleGuard`)
- Client-side project fetch on user change with loading skeleton state

### Projects Page (`src/app/(dashboard)/projects/page.tsx`)
- Read `searchParams.userId` from App Router page props
- Resolve user role from DB (not session) for reliable admin/dev detection
- Pass `selectedUserId` to `ProjectsListWrapper` for hydration consistency

## Test Plan

- [x] Lint passes
- [x] Type-check passes
- [ ] Unit tests pass
- [x] Manual testing done

## Screenshots (if UI changes)

<!-- Admin/dev users see a searchable combobox in the projects header; regular users see no change -->
